### PR TITLE
Tracing: Reduce pixelated-noise caused by shadow intersections and reflections

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -40,10 +40,12 @@ int main()
     std::cout << "Program started...\n";
 
     Tracer tracer{};
-    tracer.setShadowColor(PresetColors::darkGrey);
+    tracer.setShadowColor(Color(0.125f, 0.125f, 0.125f));
     tracer.setBackgroundColor(PresetColors::skyBlue);
-    tracer.setMaxNumReflections(10);
-    
+    tracer.setMaximumallyReflectedColor(PresetColors::pink);
+    tracer.setMaxNumReflections(5);
+    tracer.setMinTForShadowIntersections(0.01f);
+
     FrameBuffer frameBuffer(Vec2(1000, 1000), PresetColors::skyBlue);
     Scene simpleScene = createSimpleScene();
     RenderCam frontCam  = createFrontalSceneViewCam( 100, 100, 100);

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -14,12 +14,15 @@ private:
     Color backgroundColor;
     Color maxReflectedColor;
     size_t maxNumReflections;
-    
+    float minTForShadowIntersections;
+    float reflectionalScalar;
+
     static constexpr Color DEFAULT_SHADOW_COLOR       { 0.00f, 0.00f, 0.00f };
     static constexpr Color DEFAULT_BACKGROUND_COLOR   { 0.00f, 0.00f, 0.00f };
     static constexpr Color DEFAULT_MAX_REFLECTED_COLOR{ 0.05f, 0.05f, 0.05f };
     static constexpr size_t DEFAULT_MAX_NUM_REFLECTIONS = 5;
-    static constexpr float T_OFFSET_FROM_POINT = 0.001f;
+    static constexpr float DEFAULT_MIN_T_FOR_SHADOW_INTERSECTIONS = 0.01000f;
+    static constexpr float DEFAULT_REFLECTIONAL_SCALAR            = 0.00001f;
     Color traceRay(const RenderCam&, const Scene&, const Ray&, size_t) const;
     
 public:
@@ -29,4 +32,6 @@ public:
     void setBackgroundColor(const Color&);
     void setMaximumallyReflectedColor(const Color&);
     void setMaxNumReflections(size_t);
+    void setMinTForShadowIntersections(float);
+    void setReflectionalScalar(float);
 };


### PR DESCRIPTION
# Rendering: Reduce pixelated-noise caused by shadow intersections and reflections

Drastically reduces the amount of noise caused by shadow and reflection calculations, most notably by only occluding objects found by sufficiently distant shadow-ray-cast intersections.

Previously, larger values were used, and, in specific circumstances, the noise could be quite bad (see pictures at end of the PR overview).


## With smaller epsilon for object-shadow intersections
![quite noisy rendering of sphere](https://user-images.githubusercontent.com/8084757/104976966-42394680-59b3-11eb-8a32-0d26ebced302.png)


## With larger epsilon for object-shadow intersections
![not so noisy rendering of sphere](https://user-images.githubusercontent.com/8084757/104976976-46fdfa80-59b3-11eb-8a38-72b9d01fce51.png)


## Changelog
* Increase minimum t value to 0.01, as it was found to lead to the least noisy results as compared to our previous default 0.001
* Add ability to change the minimum t value explicitly that is considered when testing for shadow intersections
* Add ability to change reflectional scalar (used to avoid infinite 90 degree reflections between objects - ie by adding a slight slant to the reflected direction we avoid having to use a placeholder color as much when the number of reflections grows too high)
* Increase darkness of shadow color such that its visually clearer what is a shadow and what is not (previously the grey was too light, and often the same color as the grey pixelated noise making it hard to distinguish what was expected vs not-intended