### PR TITLE
Simplify math and time functionality

### DIFF
--- a/src/Math.hpp
+++ b/src/Math.hpp
@@ -56,11 +56,11 @@ inline constexpr float isApproximately(float a, float b, float epsilon=DEFAULT_E
     return (a > b && a - b <= epsilon) || (b > a && b - a <= epsilon);
 }
 
-constexpr float PI_1 = 3.14159265358979323846f;
+constexpr float PI = 3.14159265358979323846f;
 constexpr float PI_2 = 1.57079632679489661923f;
 constexpr float PI_4 = 0.78539816339744830962f;
-inline constexpr float radToDeg(float radians) { return radians * (180.0f / PI_1);     }
-inline constexpr float degToRad(float radians) { return radians * (PI_1   / 180.0f);   }
+inline constexpr float radToDeg(float radians) { return radians * (180.0f / PI);     }
+inline constexpr float degToRad(float radians) { return radians * (PI   / 180.0f);   }
 inline float sin(float degrees)                { return std::sinf(degToRad(degrees));  }
 inline float cos(float degrees)                { return std::cosf(degToRad(degrees));  }
 inline float tan(float degrees)                { return std::tanf(degToRad(degrees));  }
@@ -68,6 +68,7 @@ inline float asin(float degrees)               { return std::asinf(degToRad(degr
 inline float acos(float degrees)               { return std::acosf(degToRad(degrees)); }
 inline float atan(float degrees)               { return std::atanf(degToRad(degrees)); }
 inline float squareRoot(float a)               { return std::sqrtf(a);                 }
+inline float pow(float a, float b)             { return std::powf(a, b);               }
 inline constexpr float abs(float a)            { return a <= 0.0f? -a : a;             }
 inline constexpr float min(float a, float b)   { return a <= b?     a : b;             }
 inline constexpr float max(float a, float b)   { return a >= b?     a : b;             }
@@ -94,6 +95,13 @@ inline Vec3 direction(const Vec3& from, const Vec3& to)      { return Math::norm
 inline float distance(const Vec2& from, const Vec2& to)      { return Math::magnitude(to - from);                    }
 inline float distance(const Vec3& from, const Vec3& to)      { return Math::magnitude(to - from);                    }
 
+inline bool isNormalized(const Vec2& vec, float epsilon=DEFAULT_EPSILON) {
+    return isApproximately(magnitudeSquared(vec), 1.00f, epsilon);
+}
+inline bool isNormalized(const Vec3& vec, float epsilon=DEFAULT_EPSILON) {
+    return isApproximately(magnitudeSquared(vec), 1.00f, epsilon);
+}
+
 // compute the cosine [-1, 1] of the (shortest) angle between given vectors A and B
 inline float cosineSimilarity(const Vec2& a, const Vec2& b) {
     return dot(a, b) / squareRoot(magnitudeSquared(a) * magnitudeSquared(b));
@@ -102,6 +110,7 @@ inline float cosineSimilarity(const Vec2& a, const Vec2& b) {
 inline float cosineSimilarity(const Vec3& a, const Vec3& b) {
     return dot(a, b) / squareRoot(magnitudeSquared(a) * magnitudeSquared(b));
 }
+
 inline bool isSameDirection(const Vec2& a, const Vec2& b, float epsilon=DEFAULT_EPSILON) {
     return isApproximately(cosineSimilarity(a, b), 1.00f, epsilon);
 }

--- a/src/Math.hpp
+++ b/src/Math.hpp
@@ -95,13 +95,6 @@ inline Vec3 direction(const Vec3& from, const Vec3& to)      { return Math::norm
 inline float distance(const Vec2& from, const Vec2& to)      { return Math::magnitude(to - from);                    }
 inline float distance(const Vec3& from, const Vec3& to)      { return Math::magnitude(to - from);                    }
 
-inline bool isNormalized(const Vec2& vec, float epsilon=DEFAULT_EPSILON) {
-    return isApproximately(magnitudeSquared(vec), 1.00f, epsilon);
-}
-inline bool isNormalized(const Vec3& vec, float epsilon=DEFAULT_EPSILON) {
-    return isApproximately(magnitudeSquared(vec), 1.00f, epsilon);
-}
-
 // compute the cosine [-1, 1] of the (shortest) angle between given vectors A and B
 inline float cosineSimilarity(const Vec2& a, const Vec2& b) {
     return dot(a, b) / squareRoot(magnitudeSquared(a) * magnitudeSquared(b));
@@ -111,6 +104,18 @@ inline float cosineSimilarity(const Vec3& a, const Vec3& b) {
     return dot(a, b) / squareRoot(magnitudeSquared(a) * magnitudeSquared(b));
 }
 
+inline bool isNormalized(const Vec2& vec, float epsilon=DEFAULT_EPSILON) {
+    return isApproximately(magnitudeSquared(vec), 1.00f, epsilon);
+}
+inline bool isNormalized(const Vec3& vec, float epsilon=DEFAULT_EPSILON) {
+    return isApproximately(magnitudeSquared(vec), 1.00f, epsilon);
+}
+inline bool isOrthogonal(const Vec2& a, const Vec2& b, float epsilon=DEFAULT_EPSILON) {
+    return isApproximately(dot(a, b), 0.00f, epsilon);
+}
+inline bool isOrthogonal(const Vec3& a, const Vec3& b, float epsilon = DEFAULT_EPSILON) {
+    return isApproximately(dot(a, b), 0.00f, epsilon);
+}
 inline bool isSameDirection(const Vec2& a, const Vec2& b, float epsilon=DEFAULT_EPSILON) {
     return isApproximately(cosineSimilarity(a, b), 1.00f, epsilon);
 }

--- a/src/Timer.hpp
+++ b/src/Timer.hpp
@@ -33,19 +33,19 @@ public:
 
     bool isRunning()  const { return startTime.has_value() && !stopTime.has_value(); }
     bool isFinished() const { return startTime.has_value() && stopTime.has_value();  }
-    double getStartTime() const {
+    double timeStarted() const {
         if (!startTime.has_value()) {
             throw std::runtime_error("startTime undefined - requires call to start() after initialization or clear()");
         }
         return startTime.value();
     }
-    double getStopTime() const {
+    double timeStopped() const {
         if (!stopTime.has_value()) {
             throw std::runtime_error("stopTime undefined - computed in stop() after calling start()");
         }
         return stopTime.value();
     }
-    double elapsedTime() const {
+    double timeElapsed() const {
         if (isRunning()) {
             return duration(startTime.value(), currentTime().value());
         }

--- a/src/Timer.hpp
+++ b/src/Timer.hpp
@@ -35,13 +35,13 @@ public:
     bool isFinished() const { return startTime.has_value() && stopTime.has_value();  }
     double getStartTime() const {
         if (!startTime.has_value()) {
-            throw std::exception("startTime undefined - requires call to start() after initialization or clear()");
+            throw std::runtime_error("startTime undefined - requires call to start() after initialization or clear()");
         }
         return startTime.value();
     }
     double getStopTime() const {
         if (!stopTime.has_value()) {
-            throw std::exception("stopTime undefined - computed in stop() after calling start()");
+            throw std::runtime_error("stopTime undefined - computed in stop() after calling start()");
         }
         return stopTime.value();
     }


### PR DESCRIPTION
# Simplify math and time functionality
Refactors timer class such that it is just a stopwatch now, only elapsed time can be queried, not start or stoptime, thus greatly simplifying the complexity exposed by the interface (previously start and stop times could be invalid depending on the object state and would throw exceptions - but if its a stopwatch we can remove those since only elapsed time matters).

Simplifies usage of pi in angle related methods, and provides normalization and orthogonality checks, as well as a wrapper over C's powf function.