### PR TITLE
Overhaul Lighting Part 2 - Decreasing distortion and increase image quality

### DIFF
--- a/src/Cameras.hpp
+++ b/src/Cameras.hpp
@@ -137,7 +137,7 @@ public:
         if (nearClip <= 0 || nearClip >= farClip) {
             throw std::invalid_argument("near-clip must be in range of (0, farClip)");
         }
-        setupPerspectiveFromSize(this->viewportSize, this->nearClip, this->farClip);
+        setupPerspectiveFromSize(this->viewportSize, nearClip, this->farClip);
     }
     void setFarClip(float farClip) {
         if (farClip < 0) {

--- a/src/Cameras.hpp
+++ b/src/Cameras.hpp
@@ -66,16 +66,16 @@ public:
         setFarClip(DEFAULT_FAR_CLIP);
     }
     
-    const Vec3& getPosition()        const { return position;      }
-    const Vec3& getRightDir()        const { return rightDir;      }
-    const Vec3& getUpDir()           const { return upDir;         }
-    const Vec3& getForwardDir()      const { return forwardDir;    }
+    Vec3 getPosition()               const { return position;      }
+    Vec3 getRightDir()               const { return rightDir;      }
+    Vec3 getUpDir()                  const { return upDir;         }
+    Vec3 getForwardDir()             const { return forwardDir;    }
     float getHorizontalFieldOfView() const { return fieldOfView.x; }
     float getVerticalFieldOfView()   const { return fieldOfView.y; }
     float getAspectRatio()           const { return aspectRatio;   }
     float getNearClip()              const { return nearClip;      }
     float getFarClip()               const { return farClip;       }
-    const Vec2& getViewportSize()    const { return viewportSize;  }
+    Vec2 getViewportSize()           const { return viewportSize;  }
 
     Vec3 viewportToWorld(float u, float v) const {
         float centeredU = u - 0.50f;

--- a/src/Cameras.hpp
+++ b/src/Cameras.hpp
@@ -4,15 +4,15 @@
 
 
 namespace CommonResolutions {
-constexpr Vec2 SD_240p  = Vec2( 426,  240);
-constexpr Vec2 SD_360p  = Vec2( 640,  360);
-constexpr Vec2 SD_480p  = Vec2( 854,  480);
-constexpr Vec2 HD_720p  = Vec2(1280,  720);
-constexpr Vec2 HD_1080p = Vec2(1920, 1080);
-constexpr Vec2 HD_2K    = Vec2(2560, 1440);
-constexpr Vec2 HD_4K    = Vec2(3840, 2160);
-constexpr Vec2 HD_5K    = Vec2(5120, 2880);
-constexpr Vec2 HD_8K    = Vec2(7680, 4320);
+constexpr Vec2 SD_240p  = Vec2(  426,  240);
+constexpr Vec2 SD_360p  = Vec2(  640,  360);
+constexpr Vec2 SD_480p  = Vec2(  854,  480);
+constexpr Vec2 HD_720p  = Vec2( 1280,  720);
+constexpr Vec2 HD_1080p = Vec2( 1920, 1080);
+constexpr Vec2 HD_2K    = Vec2( 2560, 1440);
+constexpr Vec2 HD_4K    = Vec2( 3840, 2160);
+constexpr Vec2 HD_5K    = Vec2( 5120, 2880);
+constexpr Vec2 HD_8K    = Vec2( 7680, 4320);
 constexpr Vec2 HD_10K   = Vec2(10328, 7760);
 constexpr Vec2 HD_12K   = Vec2(12288, 6480);
 }

--- a/src/Cameras.hpp
+++ b/src/Cameras.hpp
@@ -158,8 +158,8 @@ public:
     void lookAt(const Vec3& target) {
         // if camera is pointed straight up/down, then we choose a new orthogonal vector for computing the
         // right direction (as otherwise the cross product would be zero!)
-        Vec3 directionToTarget = Math::direction(position, target);
         Vec3 tempUp{};
+        Vec3 directionToTarget = Math::direction(position, target);
         if (!Math::isParallelDirection(directionToTarget, Vec3::up())) {
             tempUp = Vec3::up();
         } else {

--- a/src/Cameras.hpp
+++ b/src/Cameras.hpp
@@ -11,7 +11,10 @@ constexpr Vec2 HD_720p  = Vec2(1280,  720);
 constexpr Vec2 HD_1080p = Vec2(1920, 1080);
 constexpr Vec2 HD_2K    = Vec2(2560, 1440);
 constexpr Vec2 HD_4K    = Vec2(3840, 2160);
+constexpr Vec2 HD_5K    = Vec2(5120, 2880);
 constexpr Vec2 HD_8K    = Vec2(7680, 4320);
+constexpr Vec2 HD_10K   = Vec2(10328, 7760);
+constexpr Vec2 HD_12K   = Vec2(12288, 6480);
 }
 
 // z-axis-aligned perspective 3d camera (rectangular-pinhole cam without lens)
@@ -126,7 +129,7 @@ public:
         if (aspectRatio <= 0) {
             throw std::invalid_argument("aspect-ratio must be greater than 0");
         }
-        Vec2 adjustedSize = Vec2(viewportSize.x, viewportSize.x / aspectRatio);
+        Vec2 adjustedSize{ viewportSize.x, viewportSize.x / aspectRatio };
         setupPerspectiveFromSize(adjustedSize, this->nearClip, this->farClip);
     }
     

--- a/src/Cameras.hpp
+++ b/src/Cameras.hpp
@@ -101,9 +101,6 @@ public:
         if (!Math::isOrthogonal(rightDir, forwardDir) || !Math::isOrthogonal(forwardDir, upDir)) {
             throw std::invalid_argument("all given orientation vectors must be orthogonal to one another");
         }
-        if (Math::isParallelDirection(upDir, forwardDir)) {
-            throw std::invalid_argument("cannot have up parallel to aim direction");
-        }
 
         this->rightDir   = rightDir;
         this->upDir      = upDir;

--- a/src/Cameras.hpp
+++ b/src/Cameras.hpp
@@ -45,8 +45,8 @@ private:
     static constexpr float DEFAULT_FAR_CLIP      =    1000.00f;
     
     // find viewport size by solving for the triangular len (width/height) in the equation `tan(fov * 0.5) = (0.5 * len) / dist`
-    Vec2 computeSizeFromHorizontalFov(float horizontalFieldOfView, float distanceToPlane) {
-        float viewportWidth  = 2.00f * distanceToPlane * Math::tan(0.50f * fieldOfView.x);
+    static Vec2 computeSizeFromHorizontalFov(float horizontalFieldOfView, float distanceToPlane, float aspectRatio) {
+        float viewportWidth  = 2.00f * distanceToPlane * Math::tan(0.50f * horizontalFieldOfView);
         float viewportHeight = viewportWidth / aspectRatio;
         return Vec2(viewportWidth, viewportHeight);
     }
@@ -62,7 +62,7 @@ private:
     
 public:
     RenderCam() {
-        Vec2 size = computeSizeFromHorizontalFov(DEFAULT_FIELD_OF_VIEW, DEFAULT_NEAR_CLIP);
+        Vec2 size = computeSizeFromHorizontalFov(DEFAULT_FIELD_OF_VIEW, DEFAULT_NEAR_CLIP, DEFAULT_ASPECT_RATIO);
         setPosition(DEFAULT_POSITION);
         setOrientation(DEFAULT_RIGHT_DIR, DEFAULT_UP_DIR, DEFAULT_FORWARD_DIR);
         setupPerspectiveFromSize(size, DEFAULT_NEAR_CLIP, DEFAULT_FAR_CLIP);
@@ -119,14 +119,14 @@ public:
         if (horizontalDegrees <= MIN_FIELD_OF_VIEW || horizontalDegrees >= MAX_FIELD_OF_VIEW) {
             throw std::invalid_argument("field-of-view must be in range (0, 180)");
         }
-        Vec2 adjustedSize = computeSizeFromHorizontalFov(horizontalDegrees, this->nearClip);
+        Vec2 adjustedSize = computeSizeFromHorizontalFov(horizontalDegrees, this->nearClip, this->aspectRatio);
         setupPerspectiveFromSize(adjustedSize, this->nearClip, this->farClip);
     }
     void setAspectRatio(float aspectRatio) {
         if (aspectRatio <= 0) {
             throw std::invalid_argument("aspect-ratio must be greater than 0");
         }
-        Vec2 adjustedSize = Vec2(viewportSize.x, viewportSize.x / this->aspectRatio);
+        Vec2 adjustedSize = Vec2(viewportSize.x, viewportSize.x / aspectRatio);
         setupPerspectiveFromSize(adjustedSize, this->nearClip, this->farClip);
     }
     
@@ -159,7 +159,6 @@ public:
         this->upDir      = Math::normalize(Math::cross(this->rightDir,   this->forwardDir));
     }
 };
-// todo: add a frustum info section...
 inline std::ostream& operator<<(std::ostream& os, const RenderCam& renderCam) {
     os << std::fixed << std::setprecision(2)
        << "RenderCam("
@@ -176,7 +175,7 @@ inline std::ostream& operator<<(std::ostream& os, const RenderCam& renderCam) {
            << "viewport-height:" << renderCam.getViewportSize().y        << "}, "
          << "Clipping{"
            << "near-plane-z:" << renderCam.getNearClip() << ","
-           << "far-plane-z:" << renderCam.getFarClip() << "}"
+           << "far-plane-z:"  << renderCam.getFarClip() << "}"
          << ")";
     return os;
 }

--- a/src/Cameras.hpp
+++ b/src/Cameras.hpp
@@ -163,8 +163,7 @@ public:
     }
 };
 inline std::ostream& operator<<(std::ostream& os, const RenderCam& renderCam) {
-    os << std::fixed << std::setprecision(2)
-       << "RenderCam("
+    os << "RenderCam("
          << "position:(" << renderCam.getPosition() << "), "
          << "Orientation{"
            << "right-axis:("   << renderCam.getRightDir()   << "),"
@@ -179,6 +178,6 @@ inline std::ostream& operator<<(std::ostream& os, const RenderCam& renderCam) {
          << "Clipping{"
            << "near-plane-z:" << renderCam.getNearClip() << ","
            << "far-plane-z:"  << renderCam.getFarClip() << "}"
-         << ")";
+       << ")";
     return os;
 }

--- a/src/Color.hpp
+++ b/src/Color.hpp
@@ -27,7 +27,7 @@ public:
     constexpr Color(double r, double g, double b) : r(static_cast<float>(r)),  g(static_cast<float>(g)),  b(static_cast<float>(b))  {}
     constexpr Color(int    r, int    g, int    b) : r(intToFloat(r)),          g(intToFloat(g)),          b(intToFloat(b))          {}
     constexpr Color(int hex)                      : r(extractRedByte(hex)),    g(extractGreenByte(hex)),  b(extractBlueByte(hex))   {}
-    constexpr Color(const Color& color)           : r(Math::clamp01(color.r)), g(Math::clamp01(color.g)), b(Math::clamp01(color.b)) {}
+    constexpr Color(const Color& intensity)           : r(Math::clamp01(intensity.r)), g(Math::clamp01(intensity.g)), b(Math::clamp01(intensity.b)) {}
 
     constexpr unsigned int getHex() {
         return ( (0xff & static_cast<unsigned char>(floatToInt(r))) << 16 ) |
@@ -41,7 +41,7 @@ inline constexpr Color operator*(const Color& lhs, const Color& rhs)  { return C
 inline constexpr Color operator*(float        lhs, const Color& rhs)  { return Color(lhs   * rhs.r, lhs   * rhs.g, lhs   * rhs.b);     }
 inline constexpr Color operator*(const Color& lhs, float        rhs)  { return Color(lhs.r * rhs,   lhs.g * rhs,   lhs.b * rhs);       }
 inline constexpr Color operator/(const Color& lhs, float        rhs)  { return Color(lhs.r / rhs,   lhs.g / rhs,   lhs.b / rhs);       }
-inline std::ostream& operator<<(std::ostream& os, const Color& color) { os << color.r << "," << color.g << "," << color.b;  return os; }
+inline std::ostream& operator<<(std::ostream& os, const Color& intensity) { os << intensity.r << "," << intensity.g << "," << intensity.b;  return os; }
 
 
 namespace Palette {

--- a/src/Color.hpp
+++ b/src/Color.hpp
@@ -41,7 +41,7 @@ inline constexpr Color operator*(const Color& lhs, const Color& rhs)  { return C
 inline constexpr Color operator*(float        lhs, const Color& rhs)  { return Color(lhs   * rhs.r, lhs   * rhs.g, lhs   * rhs.b);     }
 inline constexpr Color operator*(const Color& lhs, float        rhs)  { return Color(lhs.r * rhs,   lhs.g * rhs,   lhs.b * rhs);       }
 inline constexpr Color operator/(const Color& lhs, float        rhs)  { return Color(lhs.r / rhs,   lhs.g / rhs,   lhs.b / rhs);       }
-inline std::ostream& operator<<(std::ostream& os, const Color& intensity) { os << intensity.r << "," << intensity.g << "," << intensity.b;  return os; }
+inline std::ostream& operator<<(std::ostream& os, const Color& intensity) { os << intensity.r << "," << intensity.g << "," << intensity.b; return os; }
 
 
 namespace Palette {

--- a/src/FrameBuffers.hpp
+++ b/src/FrameBuffers.hpp
@@ -16,7 +16,7 @@ private:
     const Color initialColor;
     Color* pixels;
 
-    float computeMegaPixels(size_t width, size_t height, size_t numDigits=2) {
+    static float computeMegaPixels(size_t width, size_t height, size_t numDigits=2) {
         return Math::roundToNearestDigit((width * height) / 1000000.00f, numDigits);
     }
 

--- a/src/FrameBuffers.hpp
+++ b/src/FrameBuffers.hpp
@@ -66,17 +66,17 @@ public:
         ofs << "P6\n" << width << " " << height << "\n255\n";
         for (size_t row = 0; row < height; row++) {
             for (size_t col = 0; col < width; col++) {
-                Color color = getPixel(height - 1 - row, col);
-                ofs << static_cast<unsigned char>(color.r * 255)
-                    << static_cast<unsigned char>(color.g * 255)
-                    << static_cast<unsigned char>(color.b * 255);
+                Color intensity = getPixel(height - 1 - row, col);
+                ofs << static_cast<unsigned char>(intensity.r * 255)
+                    << static_cast<unsigned char>(intensity.g * 255)
+                    << static_cast<unsigned char>(intensity.b * 255);
             }
         }
         ofs.close();
     }
 
-    void setPixel(size_t i, const Color& color)               noexcept { pixels[i] = color;                 }
-    void setPixel(size_t row, size_t col, const Color& color) noexcept { pixels[width * row + col] = color; }
+    void setPixel(size_t i, const Color& intensity)               noexcept { pixels[i] = intensity;                 }
+    void setPixel(size_t row, size_t col, const Color& intensity) noexcept { pixels[width * row + col] = intensity; }
     
     constexpr Color getPixel(size_t i)               const noexcept { return pixels[i];                 }
     constexpr Color getPixel(size_t row, size_t col) const noexcept { return pixels[width * row + col]; }
@@ -97,7 +97,7 @@ public:
 inline std::ostream& operator<<(std::ostream& os, const FrameBuffer& frameBuffer) {
     os << std::fixed << std::setprecision(3)
        << "FrameBuffer("
-          << "initial-color:("   << frameBuffer.getDefaultColor()     << "),"
+          << "initial-intensity:("   << frameBuffer.getDefaultColor()     << "),"
           << "image-dimensions:" << frameBuffer.getImageDescription() << ", "
           << "num-elements:"     << frameBuffer.getNumPixels()        << ","
           << "aspect-ratio:"     << frameBuffer.getAspectRatio()

--- a/src/FrameBuffers.hpp
+++ b/src/FrameBuffers.hpp
@@ -50,12 +50,12 @@ public:
         ofs.close();
     }
     
-    constexpr size_t getWidth()              const noexcept { return width;            }
-    constexpr size_t getHeight()             const noexcept { return height;           }
-    constexpr size_t getNumPixels()          const noexcept { return numPixels;        }
-    constexpr float getMegaPixels()          const noexcept { return megaPixels;       }
-    constexpr const Color& getDefaultColor() const noexcept { return initialColor;     }
-    Color getColor(size_t row, size_t col)   const noexcept { return pixels[row][col]; }
+    constexpr size_t getWidth()            const noexcept { return width;            }
+    constexpr size_t getHeight()           const noexcept { return height;           }
+    constexpr size_t getNumPixels()        const noexcept { return numPixels;        }
+    constexpr float getMegaPixels()        const noexcept { return megaPixels;       }
+    constexpr Color getDefaultColor()      const noexcept { return initialColor;     }
+    Color getColor(size_t row, size_t col) const noexcept { return pixels[row][col]; }
     std::string getImageDescription() const {
         std::stringstream ss;
         ss << std::fixed << std::setprecision(2)

--- a/src/FrameBuffers.hpp
+++ b/src/FrameBuffers.hpp
@@ -11,28 +11,53 @@ private:
     const size_t width;
     const size_t height;
     const size_t numPixels;
+    const float aspectRatio;
     const float megaPixels;
     const Color initialColor;
-    std::vector<std::vector<Color>> pixels;
+    Color* pixels;
 
     float computeMegaPixels(size_t width, size_t height, size_t numDigits=2) {
         return Math::roundToNearestDigit((width * height) / 1000000.00f, numDigits);
     }
+
 public:
     FrameBuffer(size_t width, size_t height, const Color& initialColor) :
             width(width),
             height(height),
             numPixels(width * height),
+            aspectRatio(width / static_cast<float>(height)),
             megaPixels(computeMegaPixels(width, height)),
-            pixels(),
-            initialColor(initialColor) {
-        pixels.resize(height, std::vector<Color>(width, initialColor));
+            initialColor(initialColor),
+            pixels(nullptr) {
+        if (width <= 0 || height <= 0) {
+            throw std::invalid_argument("frame buffer must be have dimensions greater than zero");
+        }
+        pixels = new Color[numPixels];
+        for (int i = 0; i < numPixels; i++) {
+            pixels[i] = this->initialColor;
+        }
     }
     FrameBuffer(const Vec2& size, const Color& initialColor) :
         FrameBuffer(static_cast<size_t>(size.x), static_cast<size_t>(size.y), initialColor)
     {}
 
-    void setColor(size_t row, size_t col, const Color& color) noexcept { pixels[row][col] = color; }
+    FrameBuffer(const FrameBuffer& frameBuffer) :
+            width(width),
+            height(height),
+            numPixels(width * height),
+            aspectRatio(width / static_cast<float>(height)),
+            megaPixels(computeMegaPixels(width, height)),
+            initialColor(initialColor),
+            pixels(nullptr) {
+        pixels = new Color[numPixels];
+        memcpy(pixels, frameBuffer.pixels, sizeof(Color) * width * height);
+    }
+
+    ~FrameBuffer() {
+        if (pixels != nullptr) {
+            delete[] pixels;
+        }
+    }
 
     // save framebuffer as an array of 256 rgb-colored pixels, written to file at given location
     // note that the buffer stores colors relative to top left corner, while ppm is relative to the bottom left
@@ -41,7 +66,7 @@ public:
         ofs << "P6\n" << width << " " << height << "\n255\n";
         for (size_t row = 0; row < height; row++) {
             for (size_t col = 0; col < width; col++) {
-                Color color = pixels[height - 1 - row][col];
+                Color color = getPixel(height - 1 - row, col);
                 ofs << static_cast<unsigned char>(color.r * 255)
                     << static_cast<unsigned char>(color.g * 255)
                     << static_cast<unsigned char>(color.b * 255);
@@ -49,13 +74,18 @@ public:
         }
         ofs.close();
     }
+
+    void setPixel(size_t i, const Color& color)               noexcept { pixels[i] = color;                 }
+    void setPixel(size_t row, size_t col, const Color& color) noexcept { pixels[width * row + col] = color; }
     
-    constexpr size_t getWidth()            const noexcept { return width;            }
-    constexpr size_t getHeight()           const noexcept { return height;           }
-    constexpr size_t getNumPixels()        const noexcept { return numPixels;        }
-    constexpr float getMegaPixels()        const noexcept { return megaPixels;       }
-    constexpr Color getDefaultColor()      const noexcept { return initialColor;     }
-    Color getColor(size_t row, size_t col) const noexcept { return pixels[row][col]; }
+    constexpr Color getPixel(size_t i)               const noexcept { return pixels[i];                 }
+    constexpr Color getPixel(size_t row, size_t col) const noexcept { return pixels[width * row + col]; }
+    constexpr size_t getWidth()                      const noexcept { return width;                     }
+    constexpr size_t getHeight()                     const noexcept { return height;                    }
+    constexpr float  getAspectRatio()                const noexcept { return aspectRatio;               }
+    constexpr size_t getNumPixels()                  const noexcept { return numPixels;                 }
+    constexpr float getMegaPixels()                  const noexcept { return megaPixels;                }
+    constexpr Color getDefaultColor()                const noexcept { return initialColor;              }
     std::string getImageDescription() const {
         std::stringstream ss;
         ss << std::fixed << std::setprecision(2)
@@ -65,11 +95,12 @@ public:
     }
 };
 inline std::ostream& operator<<(std::ostream& os, const FrameBuffer& frameBuffer) {
-    os << std::fixed << std::setprecision(0)
+    os << std::fixed << std::setprecision(3)
        << "FrameBuffer("
           << "initial-color:("   << frameBuffer.getDefaultColor()     << "),"
           << "image-dimensions:" << frameBuffer.getImageDescription() << ", "
-          << "num-elements:"     << frameBuffer.getNumPixels()        << ""
+          << "num-elements:"     << frameBuffer.getNumPixels()        << ","
+          << "aspect-ratio:"     << frameBuffer.getAspectRatio()
        << ")";
     return os;
 }

--- a/src/FrameBuffers.hpp
+++ b/src/FrameBuffers.hpp
@@ -61,15 +61,16 @@ public:
 
     // save framebuffer as an array of 256 rgb-colored pixels, written to file at given location
     // note that the buffer stores colors relative to top left corner, while ppm is relative to the bottom left
-    void writeToFile(const std::string& filename) {
+    void writeToFile(const std::string& filename, float gammaCorrection=2.20f) {
+        const float invGamma = 1.00f / gammaCorrection;
         std::ofstream ofs(filename + ".ppm", std::ios::out | std::ios::binary);
         ofs << "P6\n" << width << " " << height << "\n255\n";
         for (size_t row = 0; row < height; row++) {
             for (size_t col = 0; col < width; col++) {
-                Color intensity = getPixel(height - 1 - row, col);
-                ofs << static_cast<unsigned char>(intensity.r * 255)
-                    << static_cast<unsigned char>(intensity.g * 255)
-                    << static_cast<unsigned char>(intensity.b * 255);
+                Color color = getPixel(height - 1 - row, col);
+                ofs << static_cast<unsigned char>(static_cast<int>((Math::pow(color.r, invGamma) * 255) + 0.50f))
+                    << static_cast<unsigned char>(static_cast<int>((Math::pow(color.g, invGamma) * 255) + 0.50f))
+                    << static_cast<unsigned char>(static_cast<int>((Math::pow(color.b, invGamma) * 255) + 0.50f));
             }
         }
         ofs.close();
@@ -97,10 +98,10 @@ public:
 inline std::ostream& operator<<(std::ostream& os, const FrameBuffer& frameBuffer) {
     os << std::fixed << std::setprecision(3)
        << "FrameBuffer("
-          << "initial-intensity:("   << frameBuffer.getDefaultColor()     << "),"
-          << "image-dimensions:" << frameBuffer.getImageDescription() << ", "
-          << "num-elements:"     << frameBuffer.getNumPixels()        << ","
-          << "aspect-ratio:"     << frameBuffer.getAspectRatio()
+          << "initial-intensity:(" << frameBuffer.getDefaultColor()     << "),"
+          << "image-dimensions:"   << frameBuffer.getImageDescription() << ", "
+          << "num-elements:"       << frameBuffer.getNumPixels()        << ","
+          << "aspect-ratio:"       << frameBuffer.getAspectRatio()
        << ")";
     return os;
 }

--- a/src/FrameBuffers.hpp
+++ b/src/FrameBuffers.hpp
@@ -88,18 +88,14 @@ public:
     constexpr float getMegaPixels()                  const noexcept { return megaPixels;                }
     constexpr Color getDefaultColor()                const noexcept { return initialColor;              }
     std::string getImageDescription() const {
-        std::stringstream ss;
-        ss << std::fixed << std::setprecision(2)
-             << width << "X" << height
-             << "(" << getMegaPixels() << "MP)";
-        return ss.str();
+        return std::to_string(width) + "X" + std::to_string(height) +
+            "(" + std::to_string(getMegaPixels()) + "MP)";
     }
 };
 inline std::ostream& operator<<(std::ostream& os, const FrameBuffer& frameBuffer) {
-    os << std::fixed << std::setprecision(3)
-       << "FrameBuffer("
+    os << "FrameBuffer("
           << "initial-color:("   << frameBuffer.getDefaultColor()     << "),"
-          << "image-dimensions:" << frameBuffer.getImageDescription() << ", "
+          << "image-dimensions:" << frameBuffer.getImageDescription() << ","
           << "num-elements:"     << frameBuffer.getNumPixels()        << ","
           << "aspect-ratio:"     << frameBuffer.getAspectRatio()
        << ")";

--- a/src/FrameBuffers.hpp
+++ b/src/FrameBuffers.hpp
@@ -98,10 +98,10 @@ public:
 inline std::ostream& operator<<(std::ostream& os, const FrameBuffer& frameBuffer) {
     os << std::fixed << std::setprecision(3)
        << "FrameBuffer("
-          << "initial-intensity:(" << frameBuffer.getDefaultColor()     << "),"
-          << "image-dimensions:"   << frameBuffer.getImageDescription() << ", "
-          << "num-elements:"       << frameBuffer.getNumPixels()        << ","
-          << "aspect-ratio:"       << frameBuffer.getAspectRatio()
+          << "initial-color:("   << frameBuffer.getDefaultColor()     << "),"
+          << "image-dimensions:" << frameBuffer.getImageDescription() << ", "
+          << "num-elements:"     << frameBuffer.getNumPixels()        << ","
+          << "aspect-ratio:"     << frameBuffer.getAspectRatio()
        << ")";
     return os;
 }

--- a/src/Lights.hpp
+++ b/src/Lights.hpp
@@ -50,8 +50,7 @@ public:
     float getAttenuationQuadratic() const { return attenuationConstant; }
 };
 inline std::ostream& operator<<(std::ostream& os, const PointLight& light) {
-    os << std::fixed << std::setprecision(2)
-       << "PointLight("
+    os << "PointLight("
          << "position:("  << light.getPosition()  << "),"
          << "intensity:(" << light.getIntensity() << "),"
        << "Attenuation{"

--- a/src/Lights.hpp
+++ b/src/Lights.hpp
@@ -3,49 +3,61 @@
 
 
 // represents a point light in 3d space
-class Light {
+class PointLight {
 private:
     Vec3 position;
-    Color color;
-    float intensity;
-    
-    static constexpr Vec3 DEFAULT_POSITION { 0, 0, 0 };
-    static constexpr float DEFAULT_INTENSITY { 0.50f };
-    static constexpr Color DEFAULT_COLOR { 0.85f, 0.85f, 0.85f };
-    
+    Color intensity;
+    float attenuationConstant;
+    float attenuationLinear;
+    float attenuationQuadratic;
+
 public:
-    Light(const Vec3& position, const Color& color, float intensity) :
+    PointLight(const Vec3& position, const Color& intensity, float constant, float linear, float quadratic) :
         position(position),
-        color(DEFAULT_COLOR),
-        intensity(DEFAULT_INTENSITY) {}
+        intensity(intensity),
+        attenuationConstant(constant),
+        attenuationLinear(linear),
+        attenuationQuadratic(quadratic) {}
 
-    // shade given point
-    void illuminate(const Vec3& point, Vec3& lightDir, Vec3& lightIntensity, float& distance) const {
+    PointLight(const Vec3& position, const Color& intensity) : PointLight(position, intensity, 1, 0, 0) {}
+    
+    // compute intensity at given point according to inverse square law with respect to distance and attenuation coefficients
+    Color computeIntensityAtPoint(const Vec3& point) const {
         float distanceSquared = Math::magnitudeSquared(point - this->position);
-        lightDir = Math::direction(this->position, point);
-        distance = Math::square(distanceSquared);
-        lightIntensity = Vec3(color.r, color.g, color.b) * (intensity / (4 * Math::PI * distanceSquared));
+        Vec3 direction = Math::direction(this->position, point);
+        float distance  = Math::square(distanceSquared);
+        return intensity / ((attenuationConstant) + (attenuationLinear * distance) + (attenuationQuadratic * distanceSquared));
     }
+    
+    void setPosition(const Vec3& position)    { this->position  = position;  }
+    void setIntensity(const Color& intensity) { this->intensity = intensity; }
 
-    void setPosition(const Vec3& position) { this->position = position; }
-    void setColor(const Color& color)      { this->color    = color;    }
-    void setIntensity(float intensity) {
-        if (intensity < 0.00f || intensity > 1.00f) {
+    // falloff in range [0.0, 1.0], with 0 being least amount of fall off and 1 being the most
+    // todo: add PROPER range checks with exceptions and then call in constructor...(research valid values)
+    void setAttenuation(float constant, float linear, float quadratic) {
+        if (constant < 0.00f || constant > 10000.00f) {
             throw std::invalid_argument("light intensity must be in range [0.00, 1.00]");
         }
-        this->intensity = intensity;
+        this->attenuationConstant  = constant;
+        this->attenuationLinear    = linear;
+        this->attenuationQuadratic = quadratic;
     }
 
-    Vec3 getPosition()   const { return position;  }
-    Color getColor()     const { return color;     }
-    float getIntensity() const { return intensity; }
+    Vec3 getPosition()              const { return position;            }
+    Color getIntensity()            const { return intensity;           }
+    float getAttenuationConstant()  const { return attenuationConstant; }
+    float getAttenuationLinear()    const { return attenuationLinear;   }
+    float getAttenuationQuadratic() const { return attenuationConstant; }
 };
-inline std::ostream& operator<<(std::ostream& os, const Light& light) {
+inline std::ostream& operator<<(std::ostream& os, const PointLight& light) {
     os << std::fixed << std::setprecision(2)
-       << "Light("
-         << "position:(" << light.getPosition() << "), "
-         << "color:("    << light.getColor()    << "), "
-         << "intensity:" << light.getColor()
+       << "PointLight("
+         << "position:("  << light.getPosition()  << "),"
+         << "intensity:(" << light.getIntensity() << "),"
+       << "Attenuation{"
+         << "constant:"  << light.getAttenuationConstant()  << ","
+         << "linear:"    << light.getAttenuationLinear()    << ","
+         << "quadratic:" << light.getAttenuationQuadratic() << "}"
        << ")";
     return os;
 }

--- a/src/Lights.hpp
+++ b/src/Lights.hpp
@@ -35,8 +35,9 @@ public:
     // falloff in range [0.0, 1.0], with 0 being least amount of fall off and 1 being the most
     // todo: add PROPER range checks with exceptions and then call in constructor...(research valid values)
     void setAttenuation(float constant, float linear, float quadratic) {
-        if (constant < 0.00f || constant > 10000.00f) {
-            throw std::invalid_argument("light intensity must be in range [0.00, 1.00]");
+        if (constant < 0.00f || linear < 0.00f || quadratic < 0.00f ||
+                Math::isApproximately(constant + linear + quadratic, 0.00f)) {
+            throw std::invalid_argument("attenuation coefficients must be greater than zero and sum to greater than zero");
         }
         this->attenuationConstant  = constant;
         this->attenuationLinear    = linear;

--- a/src/Lights.hpp
+++ b/src/Lights.hpp
@@ -33,7 +33,6 @@ public:
     void setIntensity(const Color& intensity) { this->intensity = intensity; }
 
     // falloff in range [0.0, 1.0], with 0 being least amount of fall off and 1 being the most
-    // todo: add PROPER range checks with exceptions and then call in constructor...(research valid values)
     void setAttenuation(float constant, float linear, float quadratic) {
         if (constant < 0.00f || linear < 0.00f || quadratic < 0.00f ||
                 Math::isApproximately(constant + linear + quadratic, 0.00f)) {

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -46,22 +46,25 @@ int main() {
     Vec3 localOrigin{ 0, 50, 0 };
     Scene scene = createSimpleScene(localOrigin);
     FrameBuffer frameBuffer{ CommonResolutions::HD_1080p, Palette::skyBlue };
-    RenderCam frontCam  = createCam(localOrigin + Vec3(0,   0,  50), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
-    RenderCam behindCam = createCam(localOrigin + Vec3(0,   0, -50), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
-    RenderCam topCam    = createCam(localOrigin + Vec3(0,  50,   0), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
-    RenderCam bottomCam = createCam(localOrigin + Vec3(0, -50,   0), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
-
-    std::cout << "Initializing target-" << frameBuffer << "\n\n";
-    std::cout << "Initializing ray-"    << tracer      << "\n\n";
-    std::cout << "Assembling "          << scene       << "\n\n";
-    std::cout << "Configuring front-"   << frontCam    << "\n\n";
-    std::cout << "Configuring behind-"  << behindCam   << "\n\n";
-    std::cout << "Configuring top-"     << topCam      << "\n\n";
-    std::cout << "Configuring bottom-"  << bottomCam   << "\n\n";
-    tracer.trace(frontCam,  scene, frameBuffer); frameBuffer.writeToFile("./scene-front");
-    tracer.trace(behindCam, scene, frameBuffer); frameBuffer.writeToFile("./scene-back");
-    tracer.trace(topCam,    scene, frameBuffer); frameBuffer.writeToFile("./scene-top");
-    tracer.trace(bottomCam, scene, frameBuffer); frameBuffer.writeToFile("./scene-bottom");
+    RenderCam frontCam    = createCam(localOrigin + Vec3(0,   0,  50), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
+    RenderCam frontTopCam = createCam(localOrigin + Vec3(0,  50,  25), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
+    RenderCam behindCam   = createCam(localOrigin + Vec3(0,   0, -50), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
+    RenderCam topCam      = createCam(localOrigin + Vec3(0,  50,   0), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
+    RenderCam bottomCam   = createCam(localOrigin + Vec3(0, -50,   0), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
+    
+    std::cout << "Initializing target-"   << frameBuffer << "\n\n";
+    std::cout << "Initializing ray-"      << tracer      << "\n\n";
+    std::cout << "Assembling "            << scene       << "\n\n";
+    std::cout << "Configuring front-"     << frontCam    << "\n\n";
+    std::cout << "Configuring front-top-" << frontTopCam << "\n\n";
+    std::cout << "Configuring behind-"    << behindCam   << "\n\n";
+    std::cout << "Configuring top-"       << topCam      << "\n\n";
+    std::cout << "Configuring bottom-"    << bottomCam   << "\n\n";
+    tracer.trace(frontCam,    scene, frameBuffer); frameBuffer.writeToFile("./scene-front");
+    tracer.trace(frontTopCam, scene, frameBuffer); frameBuffer.writeToFile("./scene-front-top");
+    tracer.trace(behindCam,   scene, frameBuffer); frameBuffer.writeToFile("./scene-back");
+    tracer.trace(topCam,      scene, frameBuffer); frameBuffer.writeToFile("./scene-top");
+    tracer.trace(bottomCam,   scene, frameBuffer); frameBuffer.writeToFile("./scene-bottom");
     std::cout << "Press ENTER to end...";
     std::cin.get();
 }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -14,21 +14,23 @@ RenderCam createCam(const Vec3& position, float fieldOfView, float viewDist, con
     return cam;
 }
 
-Scene createSimpleScene() {
+Scene createSimpleScene(const Vec3& localOrigin) {
     Material matteGreen{};
     matteGreen.setWeights(1.00f, 0.00f);
     matteGreen.setColors(Palette::darkGreen, Palette::green, Palette::lightGreen);
     matteGreen.setShininess(5);
 
     Material reflectiveGreen{};
-    reflectiveGreen.setWeights(0.00f, 1.00f);
+    reflectiveGreen.setWeights(0.10f, 0.90f);
     reflectiveGreen.setColors(Palette::darkGreen, Palette::green, Palette::lightGreen);
     reflectiveGreen.setShininess(5);
 
     Scene scene{};
-    scene.addLight(PointLight(Vec3(0, 100, 25), Palette::white, 1.50f, 1e-10f, 1e-20f));
-    scene.addSceneObject(Sphere(Vec3(0, 50, 0), 10, matteGreen));
-    scene.addSceneObject(Sphere(Vec3(0, 25, 0),  5, reflectiveGreen));
+    scene.addLight(PointLight(localOrigin + Vec3(0, 100,  25), Palette::white, 1.50f, 1e-10f, 1e-20f));
+    scene.addLight(PointLight(localOrigin + Vec3(0,   0, -25), Palette::white, 1.50f, 1e-10f, 1e-20f));
+    scene.addSceneObject(Sphere(localOrigin + Vec3(0,  20, 0), 10.0, matteGreen));
+    scene.addSceneObject(Sphere(localOrigin + Vec3(0,   0, 0),  5.0, reflectiveGreen));
+    scene.addSceneObject(Sphere(localOrigin + Vec3(0, -20, 0), 12.5, reflectiveGreen));
     return scene;
 }
 
@@ -41,13 +43,13 @@ int main() {
     tracer.setMaxNumReflections(3);
     tracer.setTracingBias(1e-02f);
 
-    Scene scene = createSimpleScene();
+    Vec3 localOrigin{ 0, 50, 0 };
+    Scene scene = createSimpleScene(localOrigin);
     FrameBuffer frameBuffer{ CommonResolutions::HD_1080p, Palette::skyBlue };
-    Vec3 target = scene.getObject(0).getCentroid();
-    RenderCam frontCam  = createCam(Vec3(0,  50,  50), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
-    RenderCam behindCam = createCam(Vec3(0,  50, -50), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
-    RenderCam topCam    = createCam(Vec3(0, 100,   0), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
-    RenderCam bottomCam = createCam(Vec3(0, -25,   0), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
+    RenderCam frontCam  = createCam(localOrigin + Vec3(0,   0,  50), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
+    RenderCam behindCam = createCam(localOrigin + Vec3(0,   0, -50), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
+    RenderCam topCam    = createCam(localOrigin + Vec3(0,  50,   0), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
+    RenderCam bottomCam = createCam(localOrigin + Vec3(0, -50,   0), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
 
     std::cout << "Initializing target-" << frameBuffer << "\n\n";
     std::cout << "Assembling "          << scene       << "\n\n";

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -15,29 +15,25 @@ RenderCam createCam(const Vec3& position, float fieldOfView, float viewDist, con
 }
 
 Scene createSimpleScene() {
-    Material brightWhite{};
-    brightWhite.setColors(Palette::gray, Palette::white, Palette::white);
-
     Material matteGreen{};
     matteGreen.setWeights(1.00f, 0.00f);
     matteGreen.setAmbientColor(Palette::lightGreen);
     matteGreen.setDiffuseColor(Palette::green);
     matteGreen.setSpecularColor(Palette::green);
-
+    
     Scene scene{};
-    scene.addLight(Light(Vec3(0, 100, 25), brightWhite));
+    scene.addLight(Light(Vec3(0, 100, 25), Palette::white, 1.00f));
     scene.addSceneObject(Sphere(Vec3(0, 50, 0), 25, matteGreen));
     return scene;
 }
 
 
-int main()
-{
+int main() {
     std::cout << "Program started...\n\n";
     Tracer tracer{}; tracer.setBackgroundColor(Palette::skyBlue);
 
     Scene scene = createSimpleScene();
-    FrameBuffer frameBuffer{ CommonResolutions::HD_5K, Palette::skyBlue };
+    FrameBuffer frameBuffer{ CommonResolutions::HD_1080p, Palette::skyBlue };
     Vec3 target = scene.getObject(0).getCentroid();
     RenderCam frontCam  = createCam(Vec3(0,  50,  50), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
     RenderCam behindCam = createCam(Vec3(0,  50, -50), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -30,7 +30,10 @@ Scene createSimpleScene() {
 
 int main() {
     std::cout << "Program started...\n\n";
-    Tracer tracer{}; tracer.setBackgroundColor(Palette::skyBlue); tracer.setMaximumallyReflectedColor(Palette::black);
+    Tracer tracer{};
+    tracer.setBackgroundColor(Palette::skyBlue);
+    tracer.setShadowColor(Color(0.125f, 0.125f, 0.125f));
+    tracer.setMaximumallyReflectedColor(Palette::black);
 
     Scene scene = createSimpleScene();
     FrameBuffer frameBuffer{ CommonResolutions::HD_1080p, Palette::skyBlue };

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -16,7 +16,7 @@ RenderCam createCam(const Vec3& position, float fieldOfView, float viewDist, con
 
 Scene createSimpleScene() {
     Material matteGreen{};
-    matteGreen.setWeights(1.00f, 0.00f);
+    matteGreen.setWeights(0.90f, 0.10f);
     matteGreen.setAmbientColor(Palette::lightGreen);
     matteGreen.setDiffuseColor(Palette::green);
     matteGreen.setSpecularColor(Palette::green);
@@ -30,7 +30,7 @@ Scene createSimpleScene() {
 
 int main() {
     std::cout << "Program started...\n\n";
-    Tracer tracer{}; tracer.setBackgroundColor(Palette::skyBlue);
+    Tracer tracer{}; tracer.setBackgroundColor(Palette::skyBlue); tracer.setMaximumallyReflectedColor(Palette::black);
 
     Scene scene = createSimpleScene();
     FrameBuffer frameBuffer{ CommonResolutions::HD_1080p, Palette::skyBlue };

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -19,10 +19,10 @@ Scene createSimpleScene() {
     matteGreen.setWeights(0.90f, 0.10f);
     matteGreen.setAmbientColor(Palette::lightGreen);
     matteGreen.setDiffuseColor(Palette::green);
-    matteGreen.setSpecularColor(Palette::green);
+    matteGreen.setSpecularColor(Palette::yellow);
     
     Scene scene{};
-    scene.addLight(Light(Vec3(0, 100, 25), Palette::white, 1.00f));
+    scene.addLight(PointLight(Vec3(0, 100, 25), Palette::white, -1, 0, 0));
     scene.addSceneObject(Sphere(Vec3(0, 50, 0), 25, matteGreen));
     return scene;
 }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -26,7 +26,6 @@ RenderCam createCam(const Vec3& position, float fieldOfView, float viewDist, con
     cam.setNearClip(viewDist);
     cam.setAspectRatio(aspectRatio);
     cam.setFieldOfView(fieldOfView);
-    cam.overrideViewportSize(Vec2(100, 25), 20.00f, 1000.00f);
     cam.lookAt(target);
     return cam;
 }
@@ -54,14 +53,23 @@ int main()
     Tracer tracer{}; tracer.setBackgroundColor(Palette::skyBlue);
 
     Scene scene = createSimpleScene();
-    FrameBuffer frameBuffer{ CommonResolutions::HD_1080p, Palette::skyBlue };
-    RenderCam frontCam  = createCam(Vec3(0,  50,  50), 110.00f, 5.00f, scene.getObject(0).getCentroid(), frameBuffer.getAspectRatio());
-    
+    FrameBuffer frameBuffer{ Vec2(1000, 1000), Palette::skyBlue };
+    Vec3 target = scene.getObject(0).getCentroid();
+    RenderCam frontCam  = createCam(Vec3(0,  50,  50), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
+    RenderCam behindCam = createCam(Vec3(0,  50, -50), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
+    RenderCam topCam    = createCam(Vec3(0, 100,   0), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
+    RenderCam bottomCam = createCam(Vec3(0, -50,   0), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
+
     std::cout << "Initializing target-" << frameBuffer << "\n\n";
     std::cout << "Assembling "          << scene       << "\n\n";
-    std::cout << "Configuring cam-"     << frontCam    << "\n\n";
-    tracer.trace(frontCam,  scene, frameBuffer); frameBuffer.writeToFile("./scene");
-    
+    std::cout << "Configuring front-"   << frontCam    << "\n\n";
+    std::cout << "Configuring behind-"  << behindCam   << "\n\n";
+    std::cout << "Configuring top-"     << topCam      << "\n\n";
+    std::cout << "Configuring bottom-"  << bottomCam   << "\n\n";
+    tracer.trace(frontCam,  scene, frameBuffer); frameBuffer.writeToFile("./scene-front");
+    tracer.trace(behindCam, scene, frameBuffer); frameBuffer.writeToFile("./scene-back");
+    tracer.trace(topCam,    scene, frameBuffer); frameBuffer.writeToFile("./scene-top");
+    tracer.trace(bottomCam, scene, frameBuffer); frameBuffer.writeToFile("./scene-bottom");
     std::cout << "Press ENTER to end...";
     std::cin.get();
 }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -24,10 +24,9 @@ RenderCam createCam(const Vec3& position, float fieldOfView, float viewDist, con
     RenderCam cam{};
     cam.setPosition(position);
     cam.setNearClip(viewDist);
-    cam.setFarClip(10000.00f);
     cam.setAspectRatio(aspectRatio);
     cam.setFieldOfView(fieldOfView);
-    cam.overrideViewportSize(Vec2(110.0, 27.5), 20.00f);
+    cam.overrideViewportSize(Vec2(100, 25), 20.00f, 1000.00f);
     cam.lookAt(target);
     return cam;
 }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -21,13 +21,14 @@ Scene createSimpleScene() {
     matteGreen.setShininess(5);
 
     Material reflectiveGreen{};
-    reflectiveGreen.setWeights(0.50f, 0.50f);
+    reflectiveGreen.setWeights(0, 1);
     reflectiveGreen.setColors(Palette::darkGreen, Palette::green, Palette::lightGreen);
     reflectiveGreen.setShininess(5);
 
     Scene scene{};
     scene.addLight(PointLight(Vec3(0, 100, 25), Palette::white, 1.50f, 1e-10f, 1e-20f));
-    scene.addSceneObject(Sphere(Vec3(0, 50, 0), 25, reflectiveGreen));
+    scene.addSceneObject(Sphere(Vec3(0, 50, 0), 10, matteGreen));
+    scene.addSceneObject(Sphere(Vec3(0, 25, 0),  5, reflectiveGreen));
     return scene;
 }
 
@@ -38,6 +39,7 @@ int main() {
     tracer.setBackgroundColor(Palette::skyBlue);
     tracer.setShadowColor(Color(0.125f, 0.125f, 0.125f));
     tracer.setMaxNumReflections(3);
+    tracer.setTracingBias(1e-02f);
 
     Scene scene = createSimpleScene();
     FrameBuffer frameBuffer{ CommonResolutions::HD_1080p, Palette::skyBlue };

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -40,6 +40,7 @@ Scene createSimpleScene(const Vec3& localOrigin) {
 }
 
 
+// todo: figure out inverted reflection issue...
 int main() {
     std::cout << "Program started...\n\n";
     Tracer tracer{};
@@ -52,7 +53,7 @@ int main() {
     Vec3 eyeTarget{ 0, 50, 0 };
     Vec3 sceneOrigin{ 0, 0, 0 };
     Scene scene = createSimpleScene(sceneOrigin);
-    FrameBuffer frameBuffer{ CommonResolutions::HD_4K, Palette::skyBlue };
+    FrameBuffer frameBuffer{ CommonResolutions::HD_720p, Palette::skyBlue };
     RenderCam frontCam    = createCam(eyeTarget + Vec3(0,   0,  50), 120.00f, 0.50f, eyeTarget, frameBuffer.getAspectRatio());
     RenderCam frontTopCam = createCam(eyeTarget + Vec3(0,  50,  25), 120.00f, 0.50f, eyeTarget, frameBuffer.getAspectRatio());
     RenderCam behindCam   = createCam(eyeTarget + Vec3(0,   0, -50), 120.00f, 0.50f, eyeTarget, frameBuffer.getAspectRatio());

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -16,21 +16,21 @@ RenderCam createCam(const Vec3& position, float fieldOfView, float viewDist, con
 
 Scene createSimpleScene(const Vec3& localOrigin) {
     Material matteGreen{};
-    matteGreen.setWeights(1.00f, 0.00f);
+    matteGreen.setWeights(0.82, 0.18);
     matteGreen.setColors(Palette::darkGreen, Palette::green, Palette::lightGreen);
     matteGreen.setShininess(5);
 
     Material reflectiveGreen{};
-    reflectiveGreen.setWeights(0.10f, 0.90f);
+    reflectiveGreen.setWeights(0.10, 0.90);
     reflectiveGreen.setColors(Palette::darkGreen, Palette::green, Palette::lightGreen);
     reflectiveGreen.setShininess(5);
 
     Scene scene{};
-    scene.addLight(PointLight(localOrigin + Vec3(0, 100, 25), Palette::white, 1.50f, 1e-10f, 1e-20f));
-    scene.addLight(PointLight(localOrigin + Vec3(0,   0, 25), Palette::white, 1.50f, 1e-10f, 1e-20f));
-    scene.addSceneObject(Sphere(localOrigin + Vec3(0,  20, 0), 10.0, matteGreen));
-    scene.addSceneObject(Sphere(localOrigin + Vec3(0,   0, 0),  5.0, reflectiveGreen));
-    scene.addSceneObject(Sphere(localOrigin + Vec3(0, -20, 0), 12.5, reflectiveGreen));
+    scene.addLight(PointLight(localOrigin + Vec3(0,   100, 25), Palette::white, 1.50f, 1e-10f, 1e-20f));
+    scene.addLight(PointLight(localOrigin + Vec3(0,     0, 25), Palette::white, 1.50f, 1e-10f, 1e-20f));
+    scene.addSceneObject(Sphere(localOrigin + Vec3(0,  20,  0), 10.0, matteGreen));
+    scene.addSceneObject(Sphere(localOrigin + Vec3(0,   0,  0),  5.0, reflectiveGreen));
+    scene.addSceneObject(Sphere(localOrigin + Vec3(0, -20,  0), 12.5, reflectiveGreen));
     return scene;
 }
 
@@ -41,7 +41,7 @@ int main() {
     tracer.setBackgroundColor(Palette::skyBlue);
     tracer.setShadowColor(Color(0.125f, 0.125f, 0.125f));
     tracer.setMaxNumReflections(3);
-    tracer.setTracingBias(1e-02f);
+    tracer.setTracingBias(1e-05f);
 
     Vec3 localOrigin{ 0, 50, 0 };
     Scene scene = createSimpleScene(localOrigin);

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -17,13 +17,17 @@ RenderCam createCam(const Vec3& position, float fieldOfView, float viewDist, con
 Scene createSimpleScene() {
     Material matteGreen{};
     matteGreen.setWeights(0.90f, 0.10f);
-    matteGreen.setAmbientColor(Palette::lightGreen);
-    matteGreen.setDiffuseColor(Palette::green);
-    matteGreen.setSpecularColor(Palette::yellow);
-    
+    matteGreen.setColors(Palette::darkGreen, Palette::green, Palette::lightGreen);
+    matteGreen.setShininess(5);
+
+    Material reflectiveGreen{};
+    reflectiveGreen.setWeights(0.50f, 0.50f);
+    reflectiveGreen.setColors(Palette::darkGreen, Palette::green, Palette::lightGreen);
+    reflectiveGreen.setShininess(5);
+
     Scene scene{};
-    scene.addLight(PointLight(Vec3(0, 100, 25), Palette::white, -1, 0, 0));
-    scene.addSceneObject(Sphere(Vec3(0, 50, 0), 25, matteGreen));
+    scene.addLight(PointLight(Vec3(0, 100, 25), Palette::white, 1.50f, 1e-10f, 1e-20f));
+    scene.addSceneObject(Sphere(Vec3(0, 50, 0), 25, reflectiveGreen));
     return scene;
 }
 
@@ -33,7 +37,7 @@ int main() {
     Tracer tracer{};
     tracer.setBackgroundColor(Palette::skyBlue);
     tracer.setShadowColor(Color(0.125f, 0.125f, 0.125f));
-    tracer.setMaximumallyReflectedColor(Palette::black);
+    tracer.setMaxNumReflections(3);
 
     Scene scene = createSimpleScene();
     FrameBuffer frameBuffer{ CommonResolutions::HD_1080p, Palette::skyBlue };
@@ -41,7 +45,7 @@ int main() {
     RenderCam frontCam  = createCam(Vec3(0,  50,  50), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
     RenderCam behindCam = createCam(Vec3(0,  50, -50), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
     RenderCam topCam    = createCam(Vec3(0, 100,   0), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
-    RenderCam bottomCam = createCam(Vec3(0, -50,   0), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
+    RenderCam bottomCam = createCam(Vec3(0, -25,   0), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
 
     std::cout << "Initializing target-" << frameBuffer << "\n\n";
     std::cout << "Assembling "          << scene       << "\n\n";

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -16,12 +16,12 @@ RenderCam createCam(const Vec3& position, float fieldOfView, float viewDist, con
 
 Scene createSimpleScene() {
     Material matteGreen{};
-    matteGreen.setWeights(0.90f, 0.10f);
+    matteGreen.setWeights(1.00f, 0.00f);
     matteGreen.setColors(Palette::darkGreen, Palette::green, Palette::lightGreen);
     matteGreen.setShininess(5);
 
     Material reflectiveGreen{};
-    reflectiveGreen.setWeights(0, 1);
+    reflectiveGreen.setWeights(0.00f, 1.00f);
     reflectiveGreen.setColors(Palette::darkGreen, Palette::green, Palette::lightGreen);
     reflectiveGreen.setShininess(5);
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -26,8 +26,8 @@ Scene createSimpleScene(const Vec3& localOrigin) {
     reflectiveGreen.setShininess(5);
 
     Scene scene{};
-    scene.addLight(PointLight(localOrigin + Vec3(0, 100,  25), Palette::white, 1.50f, 1e-10f, 1e-20f));
-    scene.addLight(PointLight(localOrigin + Vec3(0,   0, -25), Palette::white, 1.50f, 1e-10f, 1e-20f));
+    scene.addLight(PointLight(localOrigin + Vec3(0, 100, 25), Palette::white, 1.50f, 1e-10f, 1e-20f));
+    scene.addLight(PointLight(localOrigin + Vec3(0,   0, 25), Palette::white, 1.50f, 1e-10f, 1e-20f));
     scene.addSceneObject(Sphere(localOrigin + Vec3(0,  20, 0), 10.0, matteGreen));
     scene.addSceneObject(Sphere(localOrigin + Vec3(0,   0, 0),  5.0, reflectiveGreen));
     scene.addSceneObject(Sphere(localOrigin + Vec3(0, -20, 0), 12.5, reflectiveGreen));
@@ -52,6 +52,7 @@ int main() {
     RenderCam bottomCam = createCam(localOrigin + Vec3(0, -50,   0), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
 
     std::cout << "Initializing target-" << frameBuffer << "\n\n";
+    std::cout << "Initializing ray-"    << tracer      << "\n\n";
     std::cout << "Assembling "          << scene       << "\n\n";
     std::cout << "Configuring front-"   << frontCam    << "\n\n";
     std::cout << "Configuring behind-"  << behindCam   << "\n\n";

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -15,22 +15,27 @@ RenderCam createCam(const Vec3& position, float fieldOfView, float viewDist, con
 }
 
 Scene createSimpleScene(const Vec3& localOrigin) {
-    Material matteGreen{};
-    matteGreen.setWeights(0.82, 0.18);
-    matteGreen.setColors(Palette::darkGreen, Palette::green, Palette::lightGreen);
-    matteGreen.setShininess(5);
+    Material reflectiveRed{};
+    reflectiveRed.setWeights(0.10f, 0.90f);
+    reflectiveRed.setColors(Palette::darkRed, Palette::red, Palette::orangeRed);
+    reflectiveRed.setShininess(15);
 
     Material reflectiveGreen{};
-    reflectiveGreen.setWeights(0.10, 0.90);
+    reflectiveGreen.setWeights(0.10f, 0.90f);
     reflectiveGreen.setColors(Palette::darkGreen, Palette::green, Palette::lightGreen);
-    reflectiveGreen.setShininess(5);
+    reflectiveGreen.setShininess(10);
+
+    Material reflectiveBlue{};
+    reflectiveBlue.setWeights(0.10f, 0.90f);
+    reflectiveBlue.setColors(Palette::darkBlue, Palette::blue, Palette::lightBlue);
+    reflectiveBlue.setShininess(5);
 
     Scene scene{};
-    scene.addLight(PointLight(localOrigin + Vec3(0,   100, 25), Palette::white, 1.50f, 1e-10f, 1e-20f));
-    scene.addLight(PointLight(localOrigin + Vec3(0,     0, 25), Palette::white, 1.50f, 1e-10f, 1e-20f));
-    scene.addSceneObject(Sphere(localOrigin + Vec3(0,  20,  0), 10.0, matteGreen));
-    scene.addSceneObject(Sphere(localOrigin + Vec3(0,   0,  0),  5.0, reflectiveGreen));
-    scene.addSceneObject(Sphere(localOrigin + Vec3(0, -20,  0), 12.5, reflectiveGreen));
+    scene.addLight(PointLight(localOrigin + Vec3(0, 100, 25), Palette::white, 0.50f, 1e-10f, 1e-20f));
+    scene.addLight(PointLight(localOrigin + Vec3(0,   0, 25), Palette::yellow, 0.50f, 1e-10f, 1e-20f));
+    scene.addSceneObject(Sphere(localOrigin + Vec3(0, 80,  0), 10.00f, reflectiveRed));
+    scene.addSceneObject(Sphere(localOrigin + Vec3(0, 55,  0), 15.00f, reflectiveGreen));
+    scene.addSceneObject(Sphere(localOrigin + Vec3(0, 20,  0), 20.00f, reflectiveBlue));
     return scene;
 }
 
@@ -39,18 +44,20 @@ int main() {
     std::cout << "Program started...\n\n";
     Tracer tracer{};
     tracer.setBackgroundColor(Palette::skyBlue);
-    tracer.setShadowColor(Color(0.125f, 0.125f, 0.125f));
+    tracer.setShadowColor(Color(0.125, 0.125, 0.125));
     tracer.setMaxNumReflections(3);
-    tracer.setTracingBias(1e-05f);
+    tracer.setShadowBias(0.02f);
+    tracer.setReflectionBias(0.08f);
 
-    Vec3 localOrigin{ 0, 50, 0 };
-    Scene scene = createSimpleScene(localOrigin);
-    FrameBuffer frameBuffer{ CommonResolutions::HD_1080p, Palette::skyBlue };
-    RenderCam frontCam    = createCam(localOrigin + Vec3(0,   0,  50), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
-    RenderCam frontTopCam = createCam(localOrigin + Vec3(0,  50,  25), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
-    RenderCam behindCam   = createCam(localOrigin + Vec3(0,   0, -50), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
-    RenderCam topCam      = createCam(localOrigin + Vec3(0,  50,   0), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
-    RenderCam bottomCam   = createCam(localOrigin + Vec3(0, -50,   0), 110.00f, 1.00f, localOrigin, frameBuffer.getAspectRatio());
+    Vec3 eyeTarget{ 0, 50, 0 };
+    Vec3 sceneOrigin{ 0, 0, 0 };
+    Scene scene = createSimpleScene(sceneOrigin);
+    FrameBuffer frameBuffer{ CommonResolutions::HD_4K, Palette::skyBlue };
+    RenderCam frontCam    = createCam(eyeTarget + Vec3(0,   0,  50), 120.00f, 0.50f, eyeTarget, frameBuffer.getAspectRatio());
+    RenderCam frontTopCam = createCam(eyeTarget + Vec3(0,  50,  25), 120.00f, 0.50f, eyeTarget, frameBuffer.getAspectRatio());
+    RenderCam behindCam   = createCam(eyeTarget + Vec3(0,   0, -50), 120.00f, 0.50f, eyeTarget, frameBuffer.getAspectRatio());
+    RenderCam topCam      = createCam(eyeTarget + Vec3(0,  50,   0), 120.00f, 0.50f, eyeTarget, frameBuffer.getAspectRatio());
+    RenderCam bottomCam   = createCam(eyeTarget + Vec3(0, -50,   0), 120.00f, 0.50f, eyeTarget, frameBuffer.getAspectRatio());
     
     std::cout << "Initializing target-"   << frameBuffer << "\n\n";
     std::cout << "Initializing ray-"      << tracer      << "\n\n";

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -4,22 +4,6 @@
 #include <iostream>
 
 
-/*
-Configuring bottom-RenderCam(
-    position:(0.00,-50.00,0.00),
-    Orientation{
-        right-axis:(-1.00,0.00,0.00),
-        upward-axis:(0.00,0.00,-1.00),
-        forward-axis:(0.00,1.00,0.00)},
-    ImagePlane{
-        aspect-ratio:4.00,
-        field-of-view-x:140.03,
-        field-of-view-y:69.02,
-        viewport-width:110.00,
-        viewport-height:27.50
-     },
-     Clipping{near-plane-z:20.00,far-plane-z:200.00})
-*/
 RenderCam createCam(const Vec3& position, float fieldOfView, float viewDist, const Vec3& target, float aspectRatio) {
     RenderCam cam{};
     cam.setPosition(position);
@@ -53,7 +37,7 @@ int main()
     Tracer tracer{}; tracer.setBackgroundColor(Palette::skyBlue);
 
     Scene scene = createSimpleScene();
-    FrameBuffer frameBuffer{ Vec2(1000, 1000), Palette::skyBlue };
+    FrameBuffer frameBuffer{ CommonResolutions::HD_5K, Palette::skyBlue };
     Vec3 target = scene.getObject(0).getCentroid();
     RenderCam frontCam  = createCam(Vec3(0,  50,  50), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());
     RenderCam behindCam = createCam(Vec3(0,  50, -50), 110.00f, 5.00f, target, frameBuffer.getAspectRatio());

--- a/src/Material.hpp
+++ b/src/Material.hpp
@@ -19,10 +19,10 @@ private:
     static constexpr Color DEFAULT_AMBIENT_COLOR  { 0.20f, 0.20f, 0.20f };
     static constexpr Color DEFAULT_DIFFUSE_COLOR  { 0.80f, 0.80f, 0.80f };
     static constexpr Color DEFAULT_SPECULAR_COLOR { 0.00f, 0.00f, 0.00f };
-    static constexpr float DEFAULT_INTRINSITY   { 1.00f };
-    static constexpr float DEFAULT_REFLECTIVITY { 0.00f };
-    static constexpr float DEFAULT_REFRACTIVITY { 0.00f };
-    static constexpr float DEFAULT_SPECULAR_EXPONENT { 0.80f };
+    static constexpr float DEFAULT_INTRINSITY        { 1.00f };
+    static constexpr float DEFAULT_REFLECTIVITY      { 0.00f };
+    static constexpr float DEFAULT_REFRACTIVITY      { 0.00f };
+    static constexpr float DEFAULT_SPECULAR_EXPONENT { 1.00f };
 
 public:
     Material(const Color& ambientColor, const Color& diffuseColor, const Color& specularColor,

--- a/src/Material.hpp
+++ b/src/Material.hpp
@@ -76,8 +76,7 @@ public:
     Color getSpecularColor() const { return specularColor;    }
 };
 inline std::ostream& operator<<(std::ostream& os, const Material& material) {
-    os << std::fixed << std::setprecision(2)
-       << "Material("
+    os << "Material("
          << "Colors{"
            << "ambient:("  << material.getAmbientColor()  << "),"
            << "diffuse:("  << material.getDiffuseColor()  << "),"

--- a/src/Material.hpp
+++ b/src/Material.hpp
@@ -4,6 +4,7 @@
 #include "Color.hpp"
 
 
+// todo: add albedo
 // color of diffuse/ambient/specular reflectance, as well as weighted intrinsic/reflectivity/refraction
 class Material {
 private:

--- a/src/Math.hpp
+++ b/src/Math.hpp
@@ -21,12 +21,14 @@ struct Vec2 {
     static constexpr Vec2 zero()  { return Vec2( 0,  0); };
     static constexpr Vec2 one()   { return Vec2( 1,  1); };
 };
-
 inline constexpr Vec2 operator+(const Vec2& lhs,  const Vec2& rhs) { return Vec2(lhs.x + rhs.x, lhs.y + rhs.y); }
 inline constexpr Vec2 operator-(const Vec2& lhs,  const Vec2& rhs) { return Vec2(lhs.x - rhs.x, lhs.y - rhs.y); }
-inline constexpr Vec2 operator/(const Vec2& lhs,  float       rhs) { return Vec2(lhs.x / rhs,   lhs.y / rhs);   }
+inline constexpr Vec2 operator*(const Vec2& lhs,  const Vec2& rhs) { return Vec2(lhs.x * rhs.x, lhs.y * rhs.y); }
 inline constexpr Vec2 operator*(const Vec2& lhs,  float       rhs) { return Vec2(lhs.x * rhs,   lhs.y * rhs);   }
 inline constexpr Vec2 operator*(float       lhs,  const Vec2& rhs) { return Vec2(lhs   * rhs.x, lhs   * rhs.y); }
+inline constexpr Vec2 operator/(const Vec2& lhs,  const Vec2& rhs) { return Vec2(lhs.x / rhs.x, lhs.y / rhs.y); }
+inline constexpr Vec2 operator/(const Vec2& lhs,  float       rhs) { return Vec2(lhs.x / rhs,   lhs.y / rhs);   }
+inline constexpr Vec2 operator/(float       lhs,  const Vec2& rhs) { return Vec2(lhs   / rhs.x, lhs   / rhs.y); }
 inline std::ostream& operator<<(std::ostream& os, const Vec2& vec) { os << vec.x << "," << vec.y; return os;    }
 
 struct Vec3 {
@@ -48,11 +50,14 @@ struct Vec3 {
     static constexpr Vec3 right()  { return Vec3( 1,  0,  0); };
     static constexpr Vec3 left()   { return Vec3(-1,  0,  0); };
 };
-inline constexpr Vec3 operator+(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z); }
-inline constexpr Vec3 operator-(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z); }
-inline constexpr Vec3 operator*(float       lhs,  const Vec3& rhs) { return Vec3(lhs   * rhs.x, lhs   * rhs.y, lhs   * rhs.z); }
-inline constexpr Vec3 operator*(const Vec3& lhs,  float       rhs) { return Vec3(lhs.x * rhs,   lhs.y * rhs,   lhs.z * rhs);   }
-inline constexpr Vec3 operator/(const Vec3& lhs,  float       rhs) { return Vec3(lhs.x / rhs,   lhs.y / rhs,   lhs.z / rhs);   }
+inline constexpr Vec3 operator+(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x + rhs.x, lhs.y + rhs.y, lhs.y + rhs.y); }
+inline constexpr Vec3 operator-(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x - rhs.x, lhs.y - rhs.y, lhs.y - rhs.y); }
+inline constexpr Vec3 operator*(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x * rhs.x, lhs.y * rhs.y, lhs.y * rhs.y); }
+inline constexpr Vec3 operator*(const Vec3& lhs,  float       rhs) { return Vec3(lhs.x * rhs,   lhs.y * rhs,   lhs.y * rhs);   }
+inline constexpr Vec3 operator*(float       lhs,  const Vec3& rhs) { return Vec3(lhs   * rhs.x, lhs   * rhs.y, lhs * rhs.y);   }
+inline constexpr Vec3 operator/(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x / rhs.x, lhs.y / rhs.y, lhs.y / rhs.y); }
+inline constexpr Vec3 operator/(const Vec3& lhs,  float       rhs) { return Vec3(lhs.x / rhs,   lhs.y / rhs,   lhs.y / rhs);   }
+inline constexpr Vec3 operator/(float       lhs,  const Vec3& rhs) { return Vec3(lhs   / rhs.x, lhs   / rhs.y, lhs   / rhs.y); }
 inline std::ostream& operator<<(std::ostream& os, const Vec3& vec) { os << vec.x << "," << vec.y << "," << vec.z; return os;   }
 
 

--- a/src/Math.hpp
+++ b/src/Math.hpp
@@ -74,6 +74,7 @@ inline constexpr float isApproximately(float a, float b, float epsilon=DEFAULT_E
     return (a == b) || (a > b && a - b <= epsilon) || (b > a && b - a <= epsilon);
 }
 
+constexpr float INF = std::numeric_limits<float>::infinity();
 constexpr float PI   = 3.14159265358979323846f;
 constexpr float PI_2 = 1.57079632679489661923f;
 constexpr float PI_4 = 0.78539816339744830962f;

--- a/src/Math.hpp
+++ b/src/Math.hpp
@@ -21,14 +21,12 @@ struct Vec2 {
     static constexpr Vec2 zero()  { return Vec2( 0,  0); };
     static constexpr Vec2 one()   { return Vec2( 1,  1); };
 };
+
 inline constexpr Vec2 operator+(const Vec2& lhs,  const Vec2& rhs) { return Vec2(lhs.x + rhs.x, lhs.y + rhs.y); }
 inline constexpr Vec2 operator-(const Vec2& lhs,  const Vec2& rhs) { return Vec2(lhs.x - rhs.x, lhs.y - rhs.y); }
-inline constexpr Vec2 operator*(const Vec2& lhs,  const Vec2& rhs) { return Vec2(lhs.x * rhs.x, lhs.y * rhs.y); }
+inline constexpr Vec2 operator/(const Vec2& lhs,  float       rhs) { return Vec2(lhs.x / rhs,   lhs.y / rhs);   }
 inline constexpr Vec2 operator*(const Vec2& lhs,  float       rhs) { return Vec2(lhs.x * rhs,   lhs.y * rhs);   }
 inline constexpr Vec2 operator*(float       lhs,  const Vec2& rhs) { return Vec2(lhs   * rhs.x, lhs   * rhs.y); }
-inline constexpr Vec2 operator/(const Vec2& lhs,  const Vec2& rhs) { return Vec2(lhs.x / rhs.x, lhs.y / rhs.y); }
-inline constexpr Vec2 operator/(const Vec2& lhs,  float       rhs) { return Vec2(lhs.x / rhs,   lhs.y / rhs);   }
-inline constexpr Vec2 operator/(float       lhs,  const Vec2& rhs) { return Vec2(lhs   / rhs.x, lhs   / rhs.y); }
 inline std::ostream& operator<<(std::ostream& os, const Vec2& vec) { os << vec.x << "," << vec.y; return os;    }
 
 struct Vec3 {
@@ -50,14 +48,11 @@ struct Vec3 {
     static constexpr Vec3 right()  { return Vec3( 1,  0,  0); };
     static constexpr Vec3 left()   { return Vec3(-1,  0,  0); };
 };
-inline constexpr Vec3 operator+(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x + rhs.x, lhs.y + rhs.y, lhs.y + rhs.y); }
-inline constexpr Vec3 operator-(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x - rhs.x, lhs.y - rhs.y, lhs.y - rhs.y); }
-inline constexpr Vec3 operator*(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x * rhs.x, lhs.y * rhs.y, lhs.y * rhs.y); }
-inline constexpr Vec3 operator*(const Vec3& lhs,  float       rhs) { return Vec3(lhs.x * rhs,   lhs.y * rhs,   lhs.y * rhs);   }
-inline constexpr Vec3 operator*(float       lhs,  const Vec3& rhs) { return Vec3(lhs   * rhs.x, lhs   * rhs.y, lhs * rhs.y);   }
-inline constexpr Vec3 operator/(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x / rhs.x, lhs.y / rhs.y, lhs.y / rhs.y); }
-inline constexpr Vec3 operator/(const Vec3& lhs,  float       rhs) { return Vec3(lhs.x / rhs,   lhs.y / rhs,   lhs.y / rhs);   }
-inline constexpr Vec3 operator/(float       lhs,  const Vec3& rhs) { return Vec3(lhs   / rhs.x, lhs   / rhs.y, lhs   / rhs.y); }
+inline constexpr Vec3 operator+(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z); }
+inline constexpr Vec3 operator-(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z); }
+inline constexpr Vec3 operator*(float       lhs,  const Vec3& rhs) { return Vec3(lhs   * rhs.x, lhs   * rhs.y, lhs   * rhs.z); }
+inline constexpr Vec3 operator*(const Vec3& lhs,  float       rhs) { return Vec3(lhs.x * rhs,   lhs.y * rhs,   lhs.z * rhs);   }
+inline constexpr Vec3 operator/(const Vec3& lhs,  float       rhs) { return Vec3(lhs.x / rhs,   lhs.y / rhs,   lhs.z / rhs);   }
 inline std::ostream& operator<<(std::ostream& os, const Vec3& vec) { os << vec.x << "," << vec.y << "," << vec.z; return os;   }
 
 

--- a/src/Rays.hpp
+++ b/src/Rays.hpp
@@ -10,10 +10,9 @@ struct Ray {
     constexpr Ray(const Vec3& origin, const Vec3& direction) : origin(origin), direction(direction) {}
 };
 inline std::ostream& operator<<(std::ostream& os, const Ray& ray) {
-    os << std::fixed << std::setprecision(2)
-       << "Ray("
-         << "origin:("    << ray.origin     << "),"
-         << "direction:(" << ray.direction  << ")"
+    os << "Ray("
+         << "origin:("    << ray.origin    << "),"
+         << "direction:(" << ray.direction << ")"
        << ")";
     return os;
 }

--- a/src/Rays.hpp
+++ b/src/Rays.hpp
@@ -17,23 +17,3 @@ inline std::ostream& operator<<(std::ostream& os, const Ray& ray) {
        << ")";
     return os;
 }
-
-struct RayHitInfo {
-    Vec3 point;
-    Vec3 normal;
-    float t;
-    RayHitInfo() = default;
-    constexpr RayHitInfo(const Vec3& point, const Vec3& normal, float t) :
-        point(point),
-        normal(normal),
-        t(t) {}
-};
-inline std::ostream& operator<<(std::ostream& os, const RayHitInfo& intersectInfo) {
-    os << std::fixed << std::setprecision(2)
-       << "IntersectInfo("
-         << "point:("  << intersectInfo.point  << "),"
-         << "normal:(" << intersectInfo.normal << "),"
-         << "t:" << intersectInfo.t
-       << ")";
-    return os;
-}

--- a/src/SceneObjects.cpp
+++ b/src/SceneObjects.cpp
@@ -3,6 +3,7 @@
 #include "Rays.hpp"
 
 
+// assumes radius greater than zero
 Sphere::Sphere(const Vec3& center, float radius, const Material& material) {
     // note that base class members can only be initialized in the body and not our typical initializer list
     this->centroid = center;
@@ -38,10 +39,9 @@ bool Sphere::intersect(const Ray& ray, IntersectInfo& result) const {
 
 std::string Sphere::getDescription() const {
     std::stringstream ss;
-    ss << std::fixed << std::setprecision(2)
-       << "Sphere("
-         << "centroid:(" << getCentroid() << "), "
-         << "material:"  << getMaterial() << ", "
+    ss << "Sphere("
+         << "centroid:(" << getCentroid() << "),"
+         << "material:"  << getMaterial() << ","
          << "radius:"    << getRadius()
        << ")";
     return ss.str();
@@ -95,11 +95,10 @@ bool Triangle::intersect(const Ray& ray, IntersectInfo& result) const {
 
 std::string Triangle::getDescription() const {
     std::stringstream ss;
-    ss << std::fixed << std::setprecision(2)
-       << "Triangle("
-         << "centroid:("        << getCentroid()    << "), "
-         << "plane-normal:(v0:" << getPlaneNormal() << "), "
-         << "material:"   << getMaterial()          << ", "
+    ss << "Triangle("
+         << "centroid:("        << getCentroid()    << "),"
+         << "plane-normal:(v0:" << getPlaneNormal() << "),"
+         << "material:"         << getMaterial()    << ","
          << "verts:[v0:(" << getVert0() << "),v1:(" << getVert1() << "),v2:(" << getVert2() << ")]"
        << ")";
     return ss.str();

--- a/src/SceneObjects.h
+++ b/src/SceneObjects.h
@@ -13,8 +13,8 @@ protected:
 public:
     ~ISceneObject() {}
 
-    const Vec3& getCentroid() const { return centroid; }
-    const Material& getMaterial() const { return material; }
+    Vec3 getCentroid()     const { return centroid; }
+    Material getMaterial() const { return material; }
 
     virtual std::string getDescription() const = 0;
     virtual bool intersect(const Ray& ray, RayHitInfo& result) const = 0;

--- a/src/SceneObjects.h
+++ b/src/SceneObjects.h
@@ -21,8 +21,7 @@ struct IntersectInfo {
     {}
 };
 inline std::ostream& operator<<(std::ostream& os, const IntersectInfo& intersectInfo) {
-    os << std::fixed << std::setprecision(2)
-       << "IntersectInfo("
+    os << "IntersectInfo("
          << "point:("  << intersectInfo.point  << "),"
          << "normal:(" << intersectInfo.normal << "),"
          << "t:"       << intersectInfo.t

--- a/src/SceneObjects.h
+++ b/src/SceneObjects.h
@@ -4,6 +4,32 @@
 #include "Rays.hpp"
 
 
+class ISceneObject;
+
+struct IntersectInfo {
+    Vec3 point;
+    Vec3 normal;
+    float t;
+    const ISceneObject* object;
+
+    constexpr IntersectInfo() : IntersectInfo(Vec3(), Vec3(), -1.00f, nullptr) {}
+    constexpr IntersectInfo(const Vec3& point, const Vec3& normal, float t, ISceneObject* object) :
+        point(point),
+        normal(normal),
+        t(t),
+        object(object)
+    {}
+};
+inline std::ostream& operator<<(std::ostream& os, const IntersectInfo& intersectInfo) {
+    os << std::fixed << std::setprecision(2)
+       << "IntersectInfo("
+         << "point:("  << intersectInfo.point  << "),"
+         << "normal:(" << intersectInfo.normal << "),"
+         << "t:"       << intersectInfo.t
+       << ")";
+    return os;
+}
+
 // virtual base class for ANY renderable (via ray-tracing) object in a scene
 class ISceneObject {
 protected:
@@ -17,12 +43,13 @@ public:
     Material getMaterial() const { return material; }
 
     virtual std::string getDescription() const = 0;
-    virtual bool intersect(const Ray& ray, RayHitInfo& result) const = 0;
+    virtual bool intersect(const Ray& ray, IntersectInfo& result) const = 0;
 };
 inline std::ostream& operator<<(std::ostream& os, const ISceneObject& sceneObject) {
     os << sceneObject.getDescription();
     return os;
 }
+
 
 class Sphere : public ISceneObject {
 private:
@@ -31,7 +58,7 @@ private:
 public:
     Sphere(const Vec3&, float, const Material&);
     virtual std::string getDescription() const override;
-    virtual bool intersect(const Ray&, RayHitInfo&) const override;
+    virtual bool intersect(const Ray&, IntersectInfo&) const override;
     float getRadius() const { return radius; }
 };
 
@@ -51,7 +78,7 @@ private:
 public:
     Triangle(const Vec3&, const Vec3&, const Vec3&, const Material&);
     virtual std::string getDescription() const override;
-    virtual bool intersect(const Ray& ray, RayHitInfo& result) const override;
+    virtual bool intersect(const Ray& ray, IntersectInfo& result) const override;
     Vec3 getVert0()       const { return vert0;       }
     Vec3 getVert1()       const { return vert1;       }
     Vec3 getVert2()       const { return vert2;       }

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -64,7 +64,7 @@ Color Tracer::traceRay(const RenderCam& renderCam, const Scene& scene, const Ray
         return backgroundColor;
     }
 
-    Color reflectedColor = backgroundColor;
+    Color reflectedColor{};
     if (intersection.object->getMaterial().getReflectivity() > 0.00f) {
         reflectedColor = traceRay(renderCam, scene, reflectRay(ray, intersection), iteration + 1);
     }
@@ -78,7 +78,6 @@ Color Tracer::traceRay(const RenderCam& renderCam, const Scene& scene, const Ray
        if (isInShadow(intersection, light, scene)) {
            return shadowColor;
        }
-
        Color diffuse  = computeDiffuseColor(intersection, light);
        Color specular = computeSpecularColor(intersection, light, renderCam);
        Color lightIntensityAtPoint = light.computeIntensityAtPoint(intersection.point);

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -72,15 +72,12 @@ Color Tracer::traceRay(const RenderCam& renderCam, const Scene& scene, const Ray
     Color nonReflectedColor = intersection.object->getMaterial().getAmbientColor();
     for (size_t index = 0; index < scene.getNumLights(); index++) {
        const PointLight light = scene.getLight(index);
-       /*
-       if (isInShadow(intersection, light, scene)) {
-           return shadowColor;
+       if (!isInShadow(intersection, light, scene)) {
+           Color diffuse  = computeDiffuseColor(intersection, light);
+           Color specular = computeSpecularColor(intersection, light, renderCam);
+           Color lightIntensityAtPoint = light.computeIntensityAtPoint(intersection.point);
+           nonReflectedColor = nonReflectedColor + lightIntensityAtPoint * (diffuse + specular);
        }
-       */
-       Color diffuse  = computeDiffuseColor(intersection, light);
-       Color specular = computeSpecularColor(intersection, light, renderCam);
-       Color lightIntensityAtPoint = light.computeIntensityAtPoint(intersection.point);
-       nonReflectedColor = nonReflectedColor + lightIntensityAtPoint * (diffuse + specular);
     }
     
     // blend intrinsic and reflected color using our light and intersected object

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -11,12 +11,11 @@
 
 Tracer::Tracer() :
     maxNumReflections(DEFAULT_MAX_NUM_REFLECTIONS),
-    shadowColor(DEFAULT_SHADOW_COLOR),
-    backgroundColor(DEFAULT_BACKGROUND_COLOR),
+    shadowColor      (DEFAULT_SHADOW_COLOR),
+    backgroundColor  (DEFAULT_BACKGROUND_COLOR),
     maxReflectedColor(DEFAULT_MAX_REFLECTED_COLOR),
-    minTForShadowIntersections(DEFAULT_MIN_T_FOR_SHADOW_INTERSECTIONS),
-    reflectionalBias(DEFAULT_REFLECTIONAL_BIAS),
-    shadowBias(DEFAULT_SHADOW_BIAS)
+    reflectionalBias (DEFAULT_REFLECTIONAL_BIAS),
+    shadowBias       (DEFAULT_SHADOW_BIAS)
 {}
 
 void Tracer::setMaxNumReflections(size_t maxNumReflections) {
@@ -30,9 +29,6 @@ void Tracer::setBackgroundColor(const Color& backgroundColor) {
 }
 void Tracer::setMaximumallyReflectedColor(const Color& maxReflectedColor) {
     this->maxReflectedColor = maxReflectedColor;
-}
-void Tracer::setMinTForShadowIntersections(float minTForShadowIntersections) {
-    this->minTForShadowIntersections = minTForShadowIntersections;
 }
 void Tracer::setReflectionalBias(float reflectionalBias) {
     this->reflectionalBias = reflectionalBias;
@@ -125,15 +121,17 @@ bool Tracer::findNearestIntersection(const Scene& scene, const Ray& ray, Interse
 // check if there exists an object blocking light from reaching our hit-point
 bool Tracer::isInShadow(const IntersectInfo& hit, const PointLight& light, const Scene& scene) const {
     Ray shadowRay{ hit.point + (hit.normal * shadowBias), Math::direction(hit.point, light.getPosition()) };
-    float tLight = Math::distance(light.getPosition(), hit.point) - minTForShadowIntersections;
+    float distanceToLight = Math::distance(shadowRay.origin, light.getPosition());
     for (size_t index = 0; index < scene.getNumObjects(); index++) {
         IntersectInfo h;
-        if (scene.getObject(index).intersect(shadowRay, h) && h.t > minTForShadowIntersections && h.t < tLight) {
+        if (scene.getObject(index).intersect(shadowRay, h) &&
+                (Math::distance(h.point, light.getPosition()) < distanceToLight)) {
             return true;
         }
     }
     return false;
 }
+
 Color Tracer::computeDiffuseColor(const IntersectInfo& hit, const PointLight& light) const {
     Vec3 directionToLight = Math::direction(hit.point, light.getPosition());
     float strengthAtAngle = Math::max(0.00f, Math::dot(hit.normal, directionToLight));

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -16,9 +16,6 @@ Tracer::Tracer() :
     maxNumReflections(DEFAULT_MAX_NUM_REFLECTIONS)
 {}
 
-void Tracer::setMaxNumReflections(size_t maxNumReflections) {
-    this->maxNumReflections = maxNumReflections;
-}
 void Tracer::setShadowColor(const Color& shadowColor) {
     this->shadowColor = shadowColor;
 }
@@ -27,6 +24,9 @@ void Tracer::setBackgroundColor(const Color& backgroundColor) {
 }
 void Tracer::setTracingBias(float tracingBias) {
     this->tracingBias = tracingBias;
+}
+void Tracer::setMaxNumReflections(size_t maxNumReflections) {
+    this->maxNumReflections = maxNumReflections;
 }
 
 // for each pixel in buffer shoot ray from camera position to its projected point on the image plane,

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -64,20 +64,19 @@ Color Tracer::traceRay(const RenderCam& renderCam, const Scene& scene, const Ray
         return backgroundColor;
     }
 
-    Color reflectedColor{};
+    Color reflectedColor{ 0, 0, 0 };
     if (intersection.object->getMaterial().getReflectivity() > 0.00f) {
         reflectedColor = traceRay(renderCam, scene, reflectRay(ray, intersection), iteration + 1);
     }
     
-    // todo: account for kS, kD, research diffuse-reflection/pure reflection, etc...
-    // todo: determine if diffuse component is same as albedo for material class
-    // todo: call with reflected ray for specular/diffuse light reflections
     Color nonReflectedColor = intersection.object->getMaterial().getAmbientColor();
     for (size_t index = 0; index < scene.getNumLights(); index++) {
        const PointLight light = scene.getLight(index);
+       /*
        if (isInShadow(intersection, light, scene)) {
            return shadowColor;
        }
+       */
        Color diffuse  = computeDiffuseColor(intersection, light);
        Color specular = computeSpecularColor(intersection, light, renderCam);
        Color lightIntensityAtPoint = light.computeIntensityAtPoint(intersection.point);

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -13,7 +13,6 @@ Tracer::Tracer() :
     maxNumReflections(DEFAULT_MAX_NUM_REFLECTIONS),
     shadowColor      (DEFAULT_SHADOW_COLOR),
     backgroundColor  (DEFAULT_BACKGROUND_COLOR),
-    maxReflectedColor(DEFAULT_MAX_REFLECTED_COLOR),
     reflectionalBias (DEFAULT_REFLECTIONAL_BIAS),
     shadowBias       (DEFAULT_SHADOW_BIAS)
 {}
@@ -26,9 +25,6 @@ void Tracer::setShadowColor(const Color& shadowColor) {
 }
 void Tracer::setBackgroundColor(const Color& backgroundColor) {
     this->backgroundColor = backgroundColor;
-}
-void Tracer::setMaximumallyReflectedColor(const Color& maxReflectedColor) {
-    this->maxReflectedColor = maxReflectedColor;
 }
 void Tracer::setReflectionalBias(float reflectionalBias) {
     this->reflectionalBias = reflectionalBias;
@@ -65,7 +61,7 @@ void Tracer::trace(const RenderCam& renderCam, const Scene& scene, FrameBuffer& 
 // todo: account for near and far clip culling (probably need to determine z dist pf object to camera and clamp on that)
 Color Tracer::traceRay(const RenderCam& renderCam, const Scene& scene, const Ray& ray, size_t iteration=0) const {
     if (iteration >= maxNumReflections) {
-        return maxReflectedColor;
+        return Color(0, 0, 0);
     }
 
     IntersectInfo hit{};

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -72,7 +72,7 @@ Color Tracer::traceRay(const RenderCam& renderCam, const Scene& scene, const Ray
     PointLight light = scene.getLight(0);
     Color ambient = intersection.object->getMaterial().getAmbientColor();
     if (isInShadow(intersection, light, scene)) {
-        return ambient;
+        return shadowColor;
     }
 
     Color lightIntensityAtPoint = light.computeIntensityAtPoint(intersection.point);
@@ -117,7 +117,7 @@ bool Tracer::isInShadow(const IntersectInfo& intersection, const PointLight& lig
     for (size_t index = 0; index < scene.getNumObjects(); index++) {
         IntersectInfo occlusion;
         if (scene.getObject(index).intersect(shadowRay, occlusion) &&
-                occlusion.object == intersection.object &&
+                occlusion.object != intersection.object &&
                 Math::distance(occlusion.point, light.getPosition()) < distanceToLight) {
             return true;
         }

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -69,7 +69,6 @@ Color Tracer::traceRay(const RenderCam& renderCam, const Scene& scene, const Ray
         return backgroundColor;
     }
 
-    // reflect our ray throughout the scene using a slight directional offset and iteration cap to avoid infinite reflections
     Color reflectedColor = backgroundColor;
     if (hit.object->getMaterial().getReflectivity() > 0.00f) {
         reflectedColor = traceRay(renderCam, scene, reflectRay(ray, hit), iteration + 1);

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -69,6 +69,9 @@ Color Tracer::traceRay(const RenderCam& renderCam, const Scene& scene, const Ray
         reflectedColor = traceRay(renderCam, scene, reflectRay(ray, intersection), iteration + 1);
     }
     
+    // todo: account for kS, kD, research diffuse-reflection/pure reflection, etc...
+    // todo: determine if diffuse component is same as albedo for material class
+    // todo: call with reflected ray for specular/diffuse light reflections
     Color nonReflectedColor = intersection.object->getMaterial().getAmbientColor();
     for (size_t index = 0; index < scene.getNumLights(); index++) {
        const PointLight light = scene.getLight(index);

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -98,7 +98,7 @@ Color Tracer::traceRay(const RenderCam& renderCam, const Scene& scene, const Ray
 // reflect our ray using a slight direction offset to avoid infinite reflections
 Ray Tracer::reflectRay(const Ray& ray, const IntersectInfo& hit) const {
     Vec3 reflectedVec = (-1.0f * ray.direction) - (2.0f * hit.normal) * (Math::dot(ray.direction, hit.normal));
-    return Ray(hit.point + reflectionalBias * hit.normal, Math::normalize(reflectedVec));
+    return Ray(hit.point + (reflectionalBias * hit.normal), Math::normalize(reflectedVec));
 }
 bool Tracer::findNearestIntersection(const Scene& scene, const Ray& ray, IntersectInfo& result) const {
     float tClosest = Math::INF;
@@ -120,7 +120,7 @@ bool Tracer::findNearestIntersection(const Scene& scene, const Ray& ray, Interse
 }
 // check if there exists an object blocking light from reaching our hit-point
 bool Tracer::isInShadow(const IntersectInfo& hit, const PointLight& light, const Scene& scene) const {
-    Ray shadowRay{ hit.point + (hit.normal * shadowBias), Math::direction(hit.point, light.getPosition()) };
+    Ray shadowRay{ hit.point + (shadowBias * hit.normal), Math::direction(hit.point, light.getPosition()) };
     float distanceToLight = Math::distance(shadowRay.origin, light.getPosition());
     for (size_t index = 0; index < scene.getNumObjects(); index++) {
         IntersectInfo h;

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -91,7 +91,7 @@ Color Tracer::traceRay(const RenderCam& renderCam, const Scene& scene, const Ray
 // reflect our ray using a slight direction offset to avoid infinite reflections
 Ray Tracer::reflectRay(const Ray& ray, const IntersectInfo& intersection) const {
     Vec3 reflectedDirection = Math::normalize(
-        (-1 * ray.direction) - (2 * Math::dot(ray.direction, intersection.normal) * intersection.normal)
+        (-1 * ray.direction) + (2 * Math::dot(ray.direction, intersection.normal) * intersection.normal)
     );
     return Ray(intersection.point + (tracingBias * intersection.normal), reflectedDirection);
 }

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -56,7 +56,7 @@ void Tracer::trace(const RenderCam& renderCam, const Scene& scene, FrameBuffer& 
 // todo: account for near and far clip culling (probably need to determine z dist pf object to camera and clamp on that)
 Color Tracer::traceRay(const RenderCam& renderCam, const Scene& scene, const Ray& ray, size_t iteration=0) const {
     if (iteration >= maxNumReflections) {
-        return backgroundColor;
+        return Color{ 0, 0, 0 };
     }
 
     IntersectInfo intersection{};

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -10,11 +10,10 @@
 
 
 Tracer::Tracer() :
-    maxNumReflections(DEFAULT_MAX_NUM_REFLECTIONS),
     shadowColor      (DEFAULT_SHADOW_COLOR),
     backgroundColor  (DEFAULT_BACKGROUND_COLOR),
-    reflectionalBias (DEFAULT_REFLECTIONAL_BIAS),
-    shadowBias       (DEFAULT_SHADOW_BIAS)
+    tracingBias      (DEFAULT_TRACING_BIAS),
+    maxNumReflections(DEFAULT_MAX_NUM_REFLECTIONS)
 {}
 
 void Tracer::setMaxNumReflections(size_t maxNumReflections) {
@@ -26,13 +25,9 @@ void Tracer::setShadowColor(const Color& shadowColor) {
 void Tracer::setBackgroundColor(const Color& backgroundColor) {
     this->backgroundColor = backgroundColor;
 }
-void Tracer::setReflectionalBias(float reflectionalBias) {
-    this->reflectionalBias = reflectionalBias;
+void Tracer::setTracingBias(float tracingBias) {
+    this->tracingBias = tracingBias;
 }
-void Tracer::setShadowBias(float shadowBias) {
-    this->shadowBias = shadowBias;
-}
-
 
 // for each pixel in buffer shoot ray from camera position to its projected point on the image plane,
 // trace it through the scene and write computed color to buffer (dynamically scheduled in parallel using openMp)
@@ -61,39 +56,41 @@ void Tracer::trace(const RenderCam& renderCam, const Scene& scene, FrameBuffer& 
 // todo: account for near and far clip culling (probably need to determine z dist pf object to camera and clamp on that)
 Color Tracer::traceRay(const RenderCam& renderCam, const Scene& scene, const Ray& ray, size_t iteration=0) const {
     if (iteration >= maxNumReflections) {
-        return Color(0, 0, 0);
+        return backgroundColor;
     }
 
-    IntersectInfo hit{};
-    if (!findNearestIntersection(scene, ray, hit)) {
+    IntersectInfo intersection{};
+    if (!findNearestIntersection(scene, ray, intersection)) {
         return backgroundColor;
     }
 
     Color reflectedColor = backgroundColor;
-    if (hit.object->getMaterial().getReflectivity() > 0.00f) {
-        reflectedColor = traceRay(renderCam, scene, reflectRay(ray, hit), iteration + 1);
+    if (intersection.object->getMaterial().getReflectivity() > 0.00f) {
+        reflectedColor = traceRay(renderCam, scene, reflectRay(ray, intersection), iteration + 1);
     }
     
     PointLight light = scene.getLight(0);
-    Color ambient = hit.object->getMaterial().getAmbientColor();
-    if (isInShadow(hit, light, scene)) {
+    Color ambient = intersection.object->getMaterial().getAmbientColor();
+    if (isInShadow(intersection, light, scene)) {
         return ambient;
     }
 
-    Color lightIntensityAtPoint = light.computeIntensityAtPoint(hit.point);
-    Color diffuse  = computeDiffuseColor(hit, light);
-    Color specular = computeSpecularColor(hit, light, renderCam);
+    Color lightIntensityAtPoint = light.computeIntensityAtPoint(intersection.point);
+    Color diffuse  = computeDiffuseColor(intersection, light);
+    Color specular = computeSpecularColor(intersection, light, renderCam);
 
     // blend intrinsic and reflected color using our light and intersected object
     Color nonReflectedColor = ambient + lightIntensityAtPoint * (diffuse + specular);
-    return hit.object->getMaterial().getReflectivity() * reflectedColor +
-           hit.object->getMaterial().getIntrinsity()   * nonReflectedColor;
+    return intersection.object->getMaterial().getReflectivity() * reflectedColor +
+           intersection.object->getMaterial().getIntrinsity()   * nonReflectedColor;
 }
 
 // reflect our ray using a slight direction offset to avoid infinite reflections
-Ray Tracer::reflectRay(const Ray& ray, const IntersectInfo& hit) const {
-    Vec3 reflectedVec = (-1.0f * ray.direction) - (2.0f * hit.normal) * (Math::dot(ray.direction, hit.normal));
-    return Ray(hit.point + (reflectionalBias * hit.normal), Math::normalize(reflectedVec));
+Ray Tracer::reflectRay(const Ray& ray, const IntersectInfo& intersection) const {
+    Vec3 reflectedDirection = Math::normalize(
+        (-1 * ray.direction) - (2 * Math::dot(ray.direction, intersection.normal) * intersection.normal)
+    );
+    return Ray(intersection.point + (tracingBias * intersection.normal), reflectedDirection);
 }
 bool Tracer::findNearestIntersection(const Scene& scene, const Ray& ray, IntersectInfo& result) const {
     float tClosest = Math::INF;
@@ -113,29 +110,34 @@ bool Tracer::findNearestIntersection(const Scene& scene, const Ray& ray, Interse
         return true;
     }
 }
-// check if there exists an object blocking light from reaching our hit-point
-bool Tracer::isInShadow(const IntersectInfo& hit, const PointLight& light, const Scene& scene) const {
-    Ray shadowRay{ hit.point + (shadowBias * hit.normal), Math::direction(hit.point, light.getPosition()) };
+// check if there exists another object blocking light from reaching our hit-point
+bool Tracer::isInShadow(const IntersectInfo& intersection, const PointLight& light, const Scene& scene) const {
+    Ray shadowRay{ intersection.point + (tracingBias * intersection.normal), Math::direction(intersection.point, light.getPosition()) };
     float distanceToLight = Math::distance(shadowRay.origin, light.getPosition());
     for (size_t index = 0; index < scene.getNumObjects(); index++) {
-        IntersectInfo h;
-        if (scene.getObject(index).intersect(shadowRay, h) &&
-                (Math::distance(h.point, light.getPosition()) < distanceToLight)) {
+        IntersectInfo occlusion;
+        if (scene.getObject(index).intersect(shadowRay, occlusion) &&
+                occlusion.object == intersection.object &&
+                Math::distance(occlusion.point, light.getPosition()) < distanceToLight) {
             return true;
         }
     }
     return false;
 }
 
-Color Tracer::computeDiffuseColor(const IntersectInfo& hit, const PointLight& light) const {
-    Vec3 directionToLight = Math::direction(hit.point, light.getPosition());
-    float strengthAtAngle = Math::max(0.00f, Math::dot(hit.normal, directionToLight));
-    return strengthAtAngle * hit.object->getMaterial().getDiffuseColor();
+Color Tracer::computeDiffuseColor(const IntersectInfo& intersection, const PointLight& light) const {
+    Vec3 directionToLight = Math::direction(intersection.point, light.getPosition());
+
+    const Material surfaceMaterial = intersection.object->getMaterial();
+    float strengthAtLightAngle = Math::max(0.00f, Math::dot(intersection.normal, directionToLight));
+    return strengthAtLightAngle * surfaceMaterial.getDiffuseColor();
 }
 
-Color Tracer::computeSpecularColor(const IntersectInfo& hit, const PointLight& light, const RenderCam& renderCam) const {
-    Vec3 directionToCam = Math::direction(hit.point, renderCam.getPosition());
+Color Tracer::computeSpecularColor(const IntersectInfo& intersection, const PointLight& light, const RenderCam& renderCam) const {
+    Vec3 directionToCam = Math::direction(intersection.point, renderCam.getPosition());
     Vec3 halfwayVec = Math::normalize(directionToCam + light.getPosition());
-    float strengthAtAngle = Math::max(0.00f, Math::dot(hit.normal, halfwayVec));
-    return Math::pow(strengthAtAngle, hit.object->getMaterial().getShininess()) * hit.object->getMaterial().getSpecularColor();
+
+    const Material surfaceMaterial = intersection.object->getMaterial();
+    float strengthAtCamAngle = Math::max(0.00f, Math::dot(intersection.normal, halfwayVec));
+    return Math::pow(strengthAtCamAngle, surfaceMaterial.getShininess()) * surfaceMaterial.getSpecularColor();
 }

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -42,10 +42,9 @@ private:
     Color traceRay(const RenderCam&, const Scene&, const Ray&, size_t) const;
 
     Ray reflectRay(const Ray&, const IntersectInfo&) const;
-    bool isInShadow(const IntersectInfo&, const Light&, const RenderCam&, const Scene&) const;
+    bool isInShadow(const IntersectInfo&, const PointLight&, const Scene&) const;
     
     bool findNearestIntersection(const Scene&, const Ray&, IntersectInfo&) const;
-    Color computeAmbientColor (const IntersectInfo&, const Light&) const;
-    Color computeDiffuseColor (const IntersectInfo&, const Light&) const;
-    Color computeSpecularColor(const IntersectInfo&, const Light&, const RenderCam&) const;
+    Color computeDiffuseColor (const IntersectInfo&, const PointLight&) const;
+    Color computeSpecularColor(const IntersectInfo&, const PointLight&, const RenderCam&) const;
 };

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -12,13 +12,15 @@ class Tracer {
 private:
     Color shadowColor;
     Color backgroundColor;
-    float tracingBias;
+    float shadowBias;
+    float reflectionBias;
     size_t maxNumReflections;
 
     static constexpr Color DEFAULT_SHADOW_COLOR     { 0.125f, 0.125f, 0.125f };
     static constexpr Color DEFAULT_BACKGROUND_COLOR { 0.500f, 0.500f, 0.500f };
     
-    static constexpr float DEFAULT_TRACING_BIAS = 1e-02f;
+    static constexpr float DEFAULT_SHADOW_BIAS     = 1e-02f;
+    static constexpr float DEFAULT_REFLECTION_BIAS = 1e-02f;
     static constexpr size_t DEFAULT_MAX_NUM_REFLECTIONS = 3;
 
 public:
@@ -26,12 +28,14 @@ public:
     void trace(const RenderCam&, const Scene&, FrameBuffer&);
     void setShadowColor(const Color&);
     void setBackgroundColor(const Color&);
-    void setTracingBias(float);
+    void setShadowBias(float);
+    void setReflectionBias(float);
     void setMaxNumReflections(size_t);
-
+    
     Color getShadowColor()        const { return shadowColor;       }
     Color getBackgroundColor()    const { return backgroundColor;   }
-    float getTracingBias()        const { return tracingBias;       }
+    float getShadowBias()         const { return shadowBias;        }
+    float getReflectionBias()     const { return reflectionBias;    }
     size_t getMaxNumReflections() const { return maxNumReflections; }
 
 private:
@@ -49,7 +53,8 @@ inline std::ostream& operator<<(std::ostream& os, const Tracer& tracer) {
     os << "Tracer("
          << "shadow-color:("       << tracer.getShadowColor()       << "),"
          << "background-color:("   << tracer.getBackgroundColor()   << "),"
-         << "tracing-bias:"        << tracer.getTracingBias()       << ", "
+         << "shadow-bias:"         << tracer.getShadowBias()        << ","
+         << "reflection-bias:"     << tracer.getReflectionBias()    << ","
          << "max-num-reflections:" << tracer.getMaxNumReflections()
        << ")";
     return os;

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -15,7 +15,8 @@ private:
     Color maxReflectedColor;
     size_t maxNumReflections;
     float minTForShadowIntersections;
-    float reflectionalScalar;
+    float reflectionalBias;
+    float shadowBias;
 
     static constexpr Color DEFAULT_SHADOW_COLOR        { 0.125f, 0.125f, 0.125f };
     static constexpr Color DEFAULT_BACKGROUND_COLOR    { 0.000f, 0.000f, 0.000f };
@@ -23,8 +24,9 @@ private:
 
     static constexpr size_t DEFAULT_MAX_NUM_REFLECTIONS           = 3;
     static constexpr float DEFAULT_MIN_T_FOR_SHADOW_INTERSECTIONS = 0.01000f;
-    static constexpr float DEFAULT_REFLECTIONAL_SCALAR            = 0.00001f;
-    
+    static constexpr float DEFAULT_REFLECTIONAL_BIAS              = 0.00001f;
+    static constexpr float DEFAULT_SHADOW_BIAS                    = 0.00010f;
+
 public:
     Tracer();
     void trace(const RenderCam&, const Scene&, FrameBuffer&);
@@ -33,7 +35,8 @@ public:
     void setMaximumallyReflectedColor(const Color&);
     void setMaxNumReflections(size_t);
     void setMinTForShadowIntersections(float);
-    void setReflectionalScalar(float);
+    void setReflectionalBias(float);
+    void setShadowBias(float);
 
 private:
     Color traceRay(const RenderCam&, const Scene&, const Ray&, size_t) const;

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -38,10 +38,10 @@ public:
 private:
     Color traceRay(const RenderCam&, const Scene&, const Ray&, size_t) const;
 
-    Ray reflectRay(const Ray&, const RayHitInfo&) const;
-    bool isInShadow(const RenderCam&, const RayHitInfo&, const Scene&, const Light&) const;
-
-    Color computeAmbientColor (const ISceneObject&, const Light&) const;
-    Color computeDiffuseColor (const ISceneObject&, const Light&, const RayHitInfo&) const;
-    Color computeSpecularColor(const ISceneObject&, const Light&, const RayHitInfo&, const RenderCam&) const;
+    Ray reflectRay(const Ray&, const IntersectInfo&) const;
+    bool isInShadow(const IntersectInfo&, const Light&, const RenderCam&, const Scene&) const;
+    
+    Color computeAmbientColor (const IntersectInfo&, const Light&) const;
+    Color computeDiffuseColor (const IntersectInfo&, const Light&) const;
+    Color computeSpecularColor(const IntersectInfo&, const Light&, const RenderCam&) const;
 };

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -26,8 +26,13 @@ public:
     void trace(const RenderCam&, const Scene&, FrameBuffer&);
     void setShadowColor(const Color&);
     void setBackgroundColor(const Color&);
-    void setMaxNumReflections(size_t);
     void setTracingBias(float);
+    void setMaxNumReflections(size_t);
+
+    Color getShadowColor()        const { return shadowColor;       }
+    Color getBackgroundColor()    const { return backgroundColor;   }
+    float getTracingBias()        const { return tracingBias;       }
+    size_t getMaxNumReflections() const { return maxNumReflections; }
 
 private:
     Color traceRay(const RenderCam&, const Scene&, const Ray&, size_t) const;
@@ -39,3 +44,13 @@ private:
     Color computeDiffuseColor (const IntersectInfo&, const PointLight&) const;
     Color computeSpecularColor(const IntersectInfo&, const PointLight&, const RenderCam&) const;
 };
+
+inline std::ostream& operator<<(std::ostream& os, const Tracer& tracer) {
+    os << "Tracer("
+         << "shadow-color:("       << tracer.getShadowColor()       << "), "
+         << "background-color:("   << tracer.getBackgroundColor()   << "), "
+         << "tracing-bias:"        << tracer.getTracingBias()       << ", "
+         << "max-num-reflections:" << tracer.getMaxNumReflections()
+       << ")";
+    return os;
+}

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -14,7 +14,6 @@ private:
     Color backgroundColor;
     Color maxReflectedColor;
     size_t maxNumReflections;
-    float minTForShadowIntersections;
     float reflectionalBias;
     float shadowBias;
 
@@ -25,7 +24,7 @@ private:
     static constexpr size_t DEFAULT_MAX_NUM_REFLECTIONS           = 3;
     static constexpr float DEFAULT_MIN_T_FOR_SHADOW_INTERSECTIONS = 0.01000f;
     static constexpr float DEFAULT_REFLECTIONAL_BIAS              = 0.00001f;
-    static constexpr float DEFAULT_SHADOW_BIAS                    = 0.00010f;
+    static constexpr float DEFAULT_SHADOW_BIAS                    = 0.01000f;
 
 public:
     Tracer();
@@ -34,7 +33,6 @@ public:
     void setBackgroundColor(const Color&);
     void setMaximumallyReflectedColor(const Color&);
     void setMaxNumReflections(size_t);
-    void setMinTForShadowIntersections(float);
     void setReflectionalBias(float);
     void setShadowBias(float);
 

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -44,6 +44,7 @@ private:
     Ray reflectRay(const Ray&, const IntersectInfo&) const;
     bool isInShadow(const IntersectInfo&, const Light&, const RenderCam&, const Scene&) const;
     
+    bool findNearestIntersection(const Scene&, const Ray&, IntersectInfo&) const;
     Color computeAmbientColor (const IntersectInfo&, const Light&) const;
     Color computeDiffuseColor (const IntersectInfo&, const Light&) const;
     Color computeSpecularColor(const IntersectInfo&, const Light&, const RenderCam&) const;

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -17,8 +17,8 @@ private:
     float reflectionalBias;
     float shadowBias;
 
-    static constexpr Color DEFAULT_SHADOW_COLOR        { 0.125f, 0.125f, 0.125f };
-    static constexpr Color DEFAULT_BACKGROUND_COLOR    { 0.000f, 0.000f, 0.000f };
+    static constexpr Color DEFAULT_SHADOW_COLOR     { 0.125f, 0.125f, 0.125f };
+    static constexpr Color DEFAULT_BACKGROUND_COLOR { 0.000f, 0.000f, 0.000f };
 
     static constexpr size_t DEFAULT_MAX_NUM_REFLECTIONS           = 3;
     static constexpr float DEFAULT_MIN_T_FOR_SHADOW_INTERSECTIONS = 0.01000f;

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -12,18 +12,14 @@ class Tracer {
 private:
     Color shadowColor;
     Color backgroundColor;
-    Color maxReflectedColor;
+    float tracingBias;
     size_t maxNumReflections;
-    float reflectionalBias;
-    float shadowBias;
 
     static constexpr Color DEFAULT_SHADOW_COLOR     { 0.125f, 0.125f, 0.125f };
-    static constexpr Color DEFAULT_BACKGROUND_COLOR { 0.000f, 0.000f, 0.000f };
-
-    static constexpr size_t DEFAULT_MAX_NUM_REFLECTIONS           = 3;
-    static constexpr float DEFAULT_MIN_T_FOR_SHADOW_INTERSECTIONS = 0.01000f;
-    static constexpr float DEFAULT_REFLECTIONAL_BIAS              = 0.00001f;
-    static constexpr float DEFAULT_SHADOW_BIAS                    = 0.01000f;
+    static constexpr Color DEFAULT_BACKGROUND_COLOR { 0.500f, 0.500f, 0.500f };
+    
+    static constexpr float DEFAULT_TRACING_BIAS = 1e-02f;
+    static constexpr size_t DEFAULT_MAX_NUM_REFLECTIONS = 3;
 
 public:
     Tracer();
@@ -31,8 +27,7 @@ public:
     void setShadowColor(const Color&);
     void setBackgroundColor(const Color&);
     void setMaxNumReflections(size_t);
-    void setReflectionalBias(float);
-    void setShadowBias(float);
+    void setTracingBias(float);
 
 private:
     Color traceRay(const RenderCam&, const Scene&, const Ray&, size_t) const;

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -19,7 +19,6 @@ private:
 
     static constexpr Color DEFAULT_SHADOW_COLOR        { 0.125f, 0.125f, 0.125f };
     static constexpr Color DEFAULT_BACKGROUND_COLOR    { 0.000f, 0.000f, 0.000f };
-    static constexpr Color DEFAULT_MAX_REFLECTED_COLOR { 1.000f, 0.750f, 0.750f };
 
     static constexpr size_t DEFAULT_MAX_NUM_REFLECTIONS           = 3;
     static constexpr float DEFAULT_MIN_T_FOR_SHADOW_INTERSECTIONS = 0.01000f;
@@ -31,7 +30,6 @@ public:
     void trace(const RenderCam&, const Scene&, FrameBuffer&);
     void setShadowColor(const Color&);
     void setBackgroundColor(const Color&);
-    void setMaximumallyReflectedColor(const Color&);
     void setMaxNumReflections(size_t);
     void setReflectionalBias(float);
     void setShadowBias(float);

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -47,8 +47,8 @@ private:
 
 inline std::ostream& operator<<(std::ostream& os, const Tracer& tracer) {
     os << "Tracer("
-         << "shadow-color:("       << tracer.getShadowColor()       << "), "
-         << "background-color:("   << tracer.getBackgroundColor()   << "), "
+         << "shadow-color:("       << tracer.getShadowColor()       << "),"
+         << "background-color:("   << tracer.getBackgroundColor()   << "),"
          << "tracing-bias:"        << tracer.getTracingBias()       << ", "
          << "max-num-reflections:" << tracer.getMaxNumReflections()
        << ")";


### PR DESCRIPTION
# Overhaul Lighting Part 2 - Decreasing distortion and increase image quality
This PR is all about improving overall image quality throughout the pipeline - namely through tackling distortion and quality problems.

## Distortion - Make the pixel to tracing pipeline consistent with aspect ratio
Makes handling aspect ratio consistent and in sync with the ratio passed in from the FrameBuffer constructor. This entailed reworking how internal state is handled in the camera class - to avoid strange corner cases, `setupPerspectiveFromSize()` is called in _all_ mutators (`setNearClip()`, `setFieldOfView()`, etc). Before, fields were recomputed on a case by case basis, but this made it vulnerable to some bugs, so instead the setup perspective helper is invoked each time for consistency and easier debugging.~~

Also, aspect ratio is now computed in the `FrameBuffer` class, and pixels are allocated in heap memory, and accessed the same way as before.

Lastly, in tune with simplifying the logic of the camera class, `getRay()` was removed (and thus the ray is now created in `Tracer.trace()` instead, with `Camera.viewportToWorld()` now taking a `w` (relative zDist) parameter.

## Quality - Colors and lighting
Applies gamma correction after computing properly diffuse/reflected/ambient/specular lighting with attenuation taken into account.