### PR TITLE
Standardize Formatting - Part 2

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -16,16 +16,16 @@ Vec3 Camera::viewportToWorld(const Vec3& viewportPosition) const {
     float centeredU = viewportPosition.x - 0.50f;
     float centeredV = viewportPosition.y - 0.50f;
     float centeredW = viewportPosition.z;
-    Vec3 viewportCenter   = eyePosition + (centeredW * forwardDir);
-    Vec3 offsetInRightDir = (centeredU * viewportSize.x * rightDir);
-    Vec3 offsetInUpDir    = (centeredV * viewportSize.y * upDir);
+    Vec3 viewportCenter   = eyePosition_ + (centeredW * forwardDir_);
+    Vec3 offsetInRightDir = (centeredU * viewportSize_.x * rightDir_);
+    Vec3 offsetInUpDir    = (centeredV * viewportSize_.y * upDir_);
     return viewportCenter + offsetInRightDir + offsetInUpDir;
 }
 void Camera::lookAt(const Vec3& target) {
     // if camera is pointed straight up/down, then we choose a new orthogonal vector for computing the
     // right direction (as otherwise the cross product would be zero!)
     Vec3 tempUp{};
-    Vec3 directionToTarget = Math::direction(eyePosition, target);
+    Vec3 directionToTarget = Math::direction(eyePosition_, target);
     if (!Math::isParallelDirection(directionToTarget, Vec3::up())) {
         tempUp = Vec3::up();
     }
@@ -33,13 +33,13 @@ void Camera::lookAt(const Vec3& target) {
         tempUp = directionToTarget.y > 0 ? Vec3::ahead() : Vec3::behind();
     }
 
-    this->forwardDir = directionToTarget;
-    this->rightDir = Math::normalize(Math::cross(this->forwardDir, tempUp));
-    this->upDir = Math::normalize(Math::cross(this->rightDir, this->forwardDir));
+    this->forwardDir_ = directionToTarget;
+    this->rightDir_   = Math::normalize(Math::cross(this->forwardDir_, tempUp));
+    this->upDir_      = Math::normalize(Math::cross(this->rightDir_, this->forwardDir_));
 }
 
 void Camera::setPosition(const Vec3& eyePosition) {
-    this->eyePosition = eyePosition;
+    this->eyePosition_ = eyePosition;
 }
 void Camera::setOrientation(const Vec3& rightDir, const Vec3& upDir, const Vec3& forwardDir) {
     if (!Math::isNormalized(forwardDir) || !Math::isNormalized(rightDir) || !Math::isNormalized(upDir)) {
@@ -48,21 +48,21 @@ void Camera::setOrientation(const Vec3& rightDir, const Vec3& upDir, const Vec3&
     if (!Math::isOrthogonal(rightDir, forwardDir) || !Math::isOrthogonal(forwardDir, upDir)) {
         throw std::invalid_argument("all given orientation vectors must be orthogonal to one another");
     }
-    this->rightDir = rightDir;
-    this->upDir = upDir;
-    this->forwardDir = forwardDir;
+    this->rightDir_   = rightDir;
+    this->upDir_      = upDir;
+    this->forwardDir_ = forwardDir;
 }
 void Camera::setNearClip(float nearClip) {
-    if (nearClip <= 0 || nearClip >= farClip) {
+    if (nearClip_ <= 0 || nearClip >= farClip_) {
         throw std::invalid_argument("near-clip must be in range of (0, farClip)");
     }
-    setupPerspectiveFromSize(this->viewportSize, nearClip, this->farClip);
+    setupPerspectiveFromSize(this->viewportSize_, nearClip, this->farClip_);
 }
 void Camera::setFarClip(float farClip) {
     if (farClip < 0) {
         throw std::invalid_argument("far-clip must be greater than 0");
     }
-    setupPerspectiveFromSize(this->viewportSize, this->nearClip, this->farClip);
+    setupPerspectiveFromSize(this->viewportSize_, this->nearClip_, this->farClip_);
 }
 // overrides field of view, aspect ratio, and clipping planes to match given viewport dimensions
 // compute field of view by solving for the fov in the equation `tan(fov * 0.5) = (0.5 * width) / dist`
@@ -76,46 +76,46 @@ void Camera::setAspectRatio(float aspectRatio) {
     if (aspectRatio <= 0) {
         throw std::invalid_argument("aspect-ratio must be greater than 0");
     }
-    Vec2 adjustedSize{ viewportSize.x, viewportSize.x / aspectRatio };
-    setupPerspectiveFromSize(adjustedSize, this->nearClip, this->farClip);
+    Vec2 adjustedSize{ viewportSize_.x, viewportSize_.x / aspectRatio };
+    setupPerspectiveFromSize(adjustedSize, this->nearClip_, this->farClip_);
 }
 void Camera::setFieldOfView(float horizontalDegrees) {
     if (horizontalDegrees <= MIN_FIELD_OF_VIEW || horizontalDegrees >= MAX_FIELD_OF_VIEW) {
         throw std::invalid_argument("field-of-view must be in range (0, 180)");
     }
-    Vec2 adjustedSize = computeSizeFromHorizontalFov(horizontalDegrees, this->nearClip, this->aspectRatio);
-    setupPerspectiveFromSize(adjustedSize, this->nearClip, this->farClip);
+    Vec2 adjustedSize = computeSizeFromHorizontalFov(horizontalDegrees, this->nearClip_, this->aspectRatio_);
+    setupPerspectiveFromSize(adjustedSize, this->nearClip_, this->farClip_);
 }
 
-constexpr Vec3 Camera::getPosition() const {
-    return eyePosition;
+constexpr Vec3 Camera::position() const {
+    return eyePosition_;
 }
-constexpr Vec3 Camera::getRightDir() const {
-    return rightDir;
+constexpr Vec3 Camera::rightDir() const {
+    return rightDir_;
 }
-constexpr Vec3 Camera::getUpDir() const {
-    return upDir;
+constexpr Vec3 Camera::upDir() const {
+    return upDir_;
 }
-constexpr Vec3 Camera::getForwardDir() const {
-    return forwardDir;
+constexpr Vec3 Camera::forwardDir() const {
+    return forwardDir_;
 }
-constexpr float Camera::getNearClip() const {
-    return nearClip;
+constexpr float Camera::nearClip() const {
+    return nearClip_;
 }
-constexpr float Camera::getFarClip() const {
-    return farClip;
+constexpr float Camera::farClip() const {
+    return farClip_;
 }
-constexpr Vec2 Camera::getViewportSize() const {
-    return viewportSize;
+constexpr Vec2 Camera::viewportSize() const {
+    return viewportSize_;
 }
-constexpr float Camera::getAspectRatio() const {
-    return aspectRatio;
+constexpr float Camera::aspectRatio() const {
+    return aspectRatio_;
 }
-constexpr float Camera::getHorizontalFieldOfView() const {
-    return fieldOfView.x;
+constexpr float Camera::horizontalFieldOfView() const {
+    return fieldOfView_.x;
 }
-constexpr float Camera::getVerticalFieldOfView() const {
-    return fieldOfView.y;
+constexpr float Camera::verticalFieldOfView() const {
+    return fieldOfView_.y;
 }
 
 // find viewport size by solving for the triangular len (width/height) in the equation `tan(fov * 0.5) = (0.5 * len) / dist`
@@ -126,30 +126,30 @@ Vec2 Camera::computeSizeFromHorizontalFov(float horizontalFieldOfView, float dis
 }
 // find field of view by solving for the fov in the equation `tan(fov * 0.5) = (0.5 * len) / dist
 void Camera::setupPerspectiveFromSize(const Vec2& viewportSize, float nearZ, float farZ) {
-    this->nearClip = nearZ;
-    this->farClip = farZ;
-    this->viewportSize = viewportSize;
-    this->aspectRatio = viewportSize.x / viewportSize.y;
-    this->fieldOfView.x = 2.00f * Math::atan(viewportSize.x / (2.00f * nearZ));
-    this->fieldOfView.y = 2.00f * Math::atan(viewportSize.y / (2.00f * nearZ));
+    this->nearClip_      = nearZ;
+    this->farClip_       = farZ;
+    this->viewportSize_  = viewportSize;
+    this->aspectRatio_   = viewportSize.x / viewportSize.y;
+    this->fieldOfView_.x = 2.00f * Math::atan(viewportSize.x / (2.00f * nearZ));
+    this->fieldOfView_.y = 2.00f * Math::atan(viewportSize.y / (2.00f * nearZ));
 }
 
 std::ostream& operator<<(std::ostream& os, const Camera& camera) {
     os << "Camera("
-         << "position:(" << camera.getPosition() << "), "
+         << "position:(" << camera.position() << "), "
          << "Orientation{"
-           << "right-axis:("   << camera.getRightDir()   << "),"
-           << "upward-axis:("  << camera.getUpDir()      << "),"
-           << "forward-axis:(" << camera.getForwardDir() << ")}, "
+           << "right-axis:("   << camera.rightDir()   << "),"
+           << "upward-axis:("  << camera.upDir()      << "),"
+           << "forward-axis:(" << camera.forwardDir() << ")}, "
          << "ImagePlane{"
-           << "aspect-ratio:"    << camera.getAspectRatio()           << ","
-           << "field-of-view-x:" << camera.getHorizontalFieldOfView() << ","
-           << "field-of-view-y:" << camera.getVerticalFieldOfView()   << ","
-           << "viewport-width:"  << camera.getViewportSize().x        << ","
-           << "viewport-height:" << camera.getViewportSize().y        << "}, "
+           << "aspect-ratio:"    << camera.aspectRatio()           << ","
+           << "field-of-view-x:" << camera.horizontalFieldOfView() << ","
+           << "field-of-view-y:" << camera.verticalFieldOfView()   << ","
+           << "viewport-width:"  << camera.viewportSize().x        << ","
+           << "viewport-height:" << camera.viewportSize().y        << "}, "
          << "Clipping{"
-           << "near-plane-z:" << camera.getNearClip() << ","
-           << "far-plane-z:"  << camera.getFarClip() << "}"
+           << "near-plane-z:" << camera.nearClip() << ","
+           << "far-plane-z:"  << camera.farClip()  << "}"
        << ")";
     return os;
 }

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -22,16 +22,16 @@ inline constexpr Vec2 HD_12K   = Vec2(12288, 6480);
 // note: fieldOfView is taken as horizontal fov, with the aspect ratio determining the verticalFov
 class Camera {
 private:
-    Vec3 eyePosition;
-    Vec3 rightDir;
-    Vec3 upDir;
-    Vec3 forwardDir;
-
-    float nearClip;
-    float farClip;
-    float aspectRatio;
-    Vec2 fieldOfView;
-    Vec2 viewportSize;
+    Vec3 eyePosition_;
+    Vec3 rightDir_;
+    Vec3 upDir_;
+    Vec3 forwardDir_;
+    
+    float nearClip_;
+    float farClip_;
+    float aspectRatio_;
+    Vec2 fieldOfView_;
+    Vec2 viewportSize_;
 
     static constexpr float MIN_FIELD_OF_VIEW =   0.00f;
     static constexpr float MAX_FIELD_OF_VIEW = 180.00f;
@@ -61,16 +61,16 @@ public:
     void setAspectRatio(float aspectRatio);
     void setFieldOfView(float horizontalDegrees);
 
-    constexpr Vec3 getPosition() const;
-    constexpr Vec3 getRightDir() const;
-    constexpr Vec3 getUpDir() const;
-    constexpr Vec3 getForwardDir() const;
-    constexpr float getNearClip() const;
-    constexpr float getFarClip() const;
-    constexpr Vec2 getViewportSize() const;
-    constexpr float getAspectRatio() const;
-    constexpr float getHorizontalFieldOfView() const;
-    constexpr float getVerticalFieldOfView() const;
+    constexpr Vec3 position() const;
+    constexpr Vec3 rightDir() const;
+    constexpr Vec3 upDir() const;
+    constexpr Vec3 forwardDir() const;
+    constexpr float nearClip() const;
+    constexpr float farClip() const;
+    constexpr Vec2  viewportSize() const;
+    constexpr float aspectRatio() const;
+    constexpr float horizontalFieldOfView() const;
+    constexpr float verticalFieldOfView() const;
 
 private:
     static Vec2 computeSizeFromHorizontalFov(float horizontalFieldOfView, float distanceToPlane, float aspectRatio);

--- a/src/Color.hpp
+++ b/src/Color.hpp
@@ -23,10 +23,10 @@ public:
     float b;
     
     Color() = default;
-    constexpr Color(float  r, float  g, float  b) : r(Math::clamp01(r)),       g(Math::clamp01(g)),       b(Math::clamp01(b))       {}
-    constexpr Color(double r, double g, double b) : r(static_cast<float>(r)),  g(static_cast<float>(g)),  b(static_cast<float>(b))  {}
-    constexpr Color(int    r, int    g, int    b) : r(intToFloat(r)),          g(intToFloat(g)),          b(intToFloat(b))          {}
-    constexpr Color(int hex)                      : r(extractRedByte(hex)),    g(extractGreenByte(hex)),  b(extractBlueByte(hex))   {}
+    constexpr Color(float  r, float  g, float  b) : r(Math::clamp01(r)),       g(Math::clamp01(g)),       b(Math::clamp01(b))      {}
+    constexpr Color(double r, double g, double b) : r(static_cast<float>(r)),  g(static_cast<float>(g)),  b(static_cast<float>(b)) {}
+    constexpr Color(int    r, int    g, int    b) : r(intToFloat(r)),          g(intToFloat(g)),          b(intToFloat(b))         {}
+    constexpr Color(int hex)                      : r(extractRedByte(hex)),    g(extractGreenByte(hex)),  b(extractBlueByte(hex))  {}
     constexpr Color(const Color& intensity)       : r(Math::clamp01(intensity.r)), g(Math::clamp01(intensity.g)), b(Math::clamp01(intensity.b)) {}
 
     constexpr unsigned int getHex() {
@@ -35,12 +35,12 @@ public:
                ( (0xff & static_cast<unsigned char>(floatToInt(b)))       );
     }
 };
-inline constexpr Color operator+(const Color& lhs, const Color& rhs)  { return Color(lhs.r + rhs.r, lhs.g + rhs.g, lhs.b + rhs.b);     }
-inline constexpr Color operator-(const Color& lhs, const Color& rhs)  { return Color(lhs.r - rhs.r, lhs.g - rhs.g, lhs.b - rhs.b);     }
-inline constexpr Color operator*(const Color& lhs, const Color& rhs)  { return Color(lhs.r * rhs.r, lhs.g * rhs.g, lhs.b * rhs.b);     }
-inline constexpr Color operator*(float        lhs, const Color& rhs)  { return Color(lhs   * rhs.r, lhs   * rhs.g, lhs   * rhs.b);     }
-inline constexpr Color operator*(const Color& lhs, float        rhs)  { return Color(lhs.r * rhs,   lhs.g * rhs,   lhs.b * rhs);       }
-inline constexpr Color operator/(const Color& lhs, float        rhs)  { return Color(lhs.r / rhs,   lhs.g / rhs,   lhs.b / rhs);       }
+inline constexpr Color operator+(const Color& lhs, const Color& rhs)  { return Color(lhs.r + rhs.r, lhs.g + rhs.g, lhs.b + rhs.b); }
+inline constexpr Color operator-(const Color& lhs, const Color& rhs)  { return Color(lhs.r - rhs.r, lhs.g - rhs.g, lhs.b - rhs.b); }
+inline constexpr Color operator*(const Color& lhs, const Color& rhs)  { return Color(lhs.r * rhs.r, lhs.g * rhs.g, lhs.b * rhs.b); }
+inline constexpr Color operator*(float        lhs, const Color& rhs)  { return Color(lhs   * rhs.r, lhs   * rhs.g, lhs   * rhs.b); }
+inline constexpr Color operator*(const Color& lhs, float        rhs)  { return Color(lhs.r * rhs,   lhs.g * rhs,   lhs.b * rhs);   }
+inline constexpr Color operator/(const Color& lhs, float        rhs)  { return Color(lhs.r / rhs,   lhs.g / rhs,   lhs.b / rhs);   }
 inline std::ostream& operator<<(std::ostream& os, const Color& intensity) { os << intensity.r << "," << intensity.g << "," << intensity.b; return os; }
 
 

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -36,9 +36,9 @@ void FrameBuffer::writeToFile(const std::string& filename, float gammaCorrection
     ofs.close();
 }
 
-void FrameBuffer::setPixel(size_t i, const Color& intensity) noexcept {
+void FrameBuffer::setPixel(size_t i, const Color& color) noexcept {
     assert((i >= 0 && i < bufferSize));
-    pixels[i] = intensity;
+    pixels[i] = color;
 }
 void FrameBuffer::setPixel(size_t row, size_t col, const Color& color) noexcept {
     assert((row >= 0 && row < height_) && (col >= 0 && col < width_));

--- a/src/FrameBuffer.h
+++ b/src/FrameBuffer.h
@@ -15,6 +15,7 @@ private:
 public:
     FrameBuffer(size_t width, size_t height);
     FrameBuffer(const Vec2& dimensions);
+    FrameBuffer() = delete;
     FrameBuffer(FrameBuffer&) = delete;
     FrameBuffer& operator=(FrameBuffer&) = delete;
 

--- a/src/Lights.cpp
+++ b/src/Lights.cpp
@@ -5,26 +5,28 @@
 
 PointLight::PointLight(const Vec3& position, const Color& intensity, float constant, float linear, float quadratic) {
     // note that base class members can only be initialized in the body and not our typical initializer list
-    this->position  = position;
-    this->intensity = intensity;
-    this->attenuationConstant  = constant;
-    this->attenuationLinear    = linear;
-    this->attenuationQuadratic = quadratic;
+    this->attenuationConstant_  = constant;
+    this->attenuationLinear_    = linear;
+    this->attenuationQuadratic_ = quadratic;
+
+    this->position_  = position;
+    this->intensity_ = intensity;
 };
 PointLight::PointLight(const Vec3& position, const Color& intensity) {
-    this->position  = position;
-    this->intensity = intensity;
-    this->attenuationConstant  = 1.00f;
-    this->attenuationLinear    = 0.00f;
-    this->attenuationQuadratic = 0.00f;
+    this->attenuationConstant_  = 1.00f;
+    this->attenuationLinear_    = 0.00f;
+    this->attenuationQuadratic_ = 0.00f;
+
+    this->position_ = position;
+    this->intensity_ = intensity;
 }
 
 // compute intensity at given point according to inverse square law with respect to distance and attenuation coefficients
 Color PointLight::computeIntensityAtPoint(const Vec3& point) const {
-    float distanceSquared = Math::magnitudeSquared(point - this->position);
-    Vec3 direction = Math::direction(this->position, point);
+    float distanceSquared = Math::magnitudeSquared(point - this->position_);
+    Vec3 direction = Math::direction(this->position_, point);
     float distance  = Math::square(distanceSquared);
-    return intensity / ((attenuationConstant) + (attenuationLinear * distance) + (attenuationQuadratic * distanceSquared));
+    return intensity_ / ((attenuationConstant_) + (attenuationLinear_ * distance) + (attenuationQuadratic_ * distanceSquared));
 }
 
 // attenuation coefficients sum to create a falloff from source in range [0.0, 1.0],
@@ -34,30 +36,30 @@ void PointLight::setAttenuation(float constant, float linear, float quadratic) {
             Math::isApproximately(constant + linear + quadratic, 0.00f)) {
         throw std::invalid_argument("attenuation coefficients must be greater than zero and sum to greater than zero");
     }
-    this->attenuationConstant  = constant;
-    this->attenuationLinear    = linear;
-    this->attenuationQuadratic = quadratic;
+    this->attenuationConstant_  = constant;
+    this->attenuationLinear_    = linear;
+    this->attenuationQuadratic_ = quadratic;
 }
 
-float PointLight::getAttenuationConstant() const {
-    return attenuationConstant;
+constexpr float PointLight::attenuationConstant() const {
+    return attenuationConstant_;
 }
-float PointLight::getAttenuationLinear() const {
-    return attenuationLinear;
+constexpr float PointLight::attenuationLinear() const {
+    return attenuationLinear_;
 }
-float PointLight::getAttenuationQuadratic() const {
-    return attenuationConstant;
+constexpr float PointLight::attenuationQuadratic() const {
+    return attenuationConstant_;
 }
 
-std::string PointLight::getDescription() const {
+std::string PointLight::description() const {
     std::stringstream ss;
     ss << "PointLight("
-         << "position:("  << getPosition()  << "),"
-         << "intensity:(" << getIntensity() << "),"
+         << "position:("  << position()  << "),"
+         << "intensity:(" << intensity() << "),"
        << "Attenuation{"
-         << "constant:"  << getAttenuationConstant()  << ","
-         << "linear:"    << getAttenuationLinear()    << ","
-         << "quadratic:" << getAttenuationQuadratic() << "}"
+         << "constant:"  << attenuationConstant()  << ","
+         << "linear:"    << attenuationLinear()    << ","
+         << "quadratic:" << attenuationQuadratic() << "}"
        << ")";
     return ss.str();
 }

--- a/src/Lights.h
+++ b/src/Lights.h
@@ -5,43 +5,39 @@
 
 class ILight {
 protected:
-    Vec3 position{};
-    Color intensity{};
-
+    Vec3 position_{};
+    Color intensity_{};
+    
 public:
-    ~ILight() {}
-
+    virtual ~ILight() = default;
     virtual Color computeIntensityAtPoint(const Vec3& point) const = 0;
-    virtual std::string getDescription() const = 0;
+    virtual std::string description() const = 0;
 
-    void setPosition(const Vec3& position)    { this->position  = position;  }
-    void setIntensity(const Color& intensity) { this->intensity = intensity; }
-
-    Vec3  getPosition()  const { return position;  }
-    Color getIntensity() const { return intensity; }
+    constexpr Vec3  position()  const { return position_;  }
+    constexpr Color intensity() const { return intensity_; }
 };
 inline std::ostream& operator<<(std::ostream& os, const ILight& light) {
-    os << light.getDescription();
+    os << light.description();
     return os;
 }
 
 
-class PointLight : public ILight {
+class PointLight final : public virtual ILight {
 private:
-    float attenuationConstant;
-    float attenuationLinear;
-    float attenuationQuadratic;
+    float attenuationConstant_;
+    float attenuationLinear_;
+    float attenuationQuadratic_;
 
 public:
     PointLight(const Vec3& position, const Color& intensity, float constant, float linear, float quadratic);
     PointLight(const Vec3& position, const Color& intensity);
 
     virtual Color computeIntensityAtPoint(const Vec3& point) const override;
-    virtual std::string getDescription() const override;
+    virtual std::string description() const override;
 
     void setAttenuation(float constant, float linear, float quadratic);
 
-    float getAttenuationConstant()  const;
-    float getAttenuationLinear()    const;
-    float getAttenuationQuadratic() const;
+    constexpr float attenuationConstant()  const;
+    constexpr float attenuationLinear()    const;
+    constexpr float attenuationQuadratic() const;
 };

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -56,7 +56,7 @@ int main() {
     Vec3 eyeTarget{ 0, 50, 0 };
     Vec3 sceneOrigin{ 0, 0, 0 };
     Scene scene = createSimpleScene(sceneOrigin);
-    FrameBuffer frameBuffer{ CommonResolutions::HD_720p };
+    FrameBuffer frameBuffer{ CommonResolutions::HD_4K };
     Camera frontCam    = createCamera(eyeTarget + Vec3(0,   0,  50), 120.00f, 0.50f, eyeTarget, frameBuffer.aspectRatio());
     Camera frontTopCam = createCamera(eyeTarget + Vec3(0,  50,  25), 120.00f, 0.50f, eyeTarget, frameBuffer.aspectRatio());
     Camera behindCam   = createCamera(eyeTarget + Vec3(0,   0, -50), 120.00f, 0.50f, eyeTarget, frameBuffer.aspectRatio());

--- a/src/Objects.cpp
+++ b/src/Objects.cpp
@@ -6,18 +6,20 @@
 // assumes radius greater than zero
 Sphere::Sphere(const Vec3& center, float radius, const Material& material) {
     // note that base class members can only be initialized in the body and not our typical initializer list
-    this->centroid = center;
-    this->material = material;
-    this->radius   = radius;
+    this->radius_ = radius;
+    this->center_ = center;
+
+    this->position_ = center;
+    this->material_ = material;
 }
 
 // given ray [X(t) = P + t] intersects sphere [| X – C | = r] IFF there exists
 // at least one real number t [t = - D.M +/- sqrt((D.M)^2 – ( |M|^2 – r^2 ))]
 // (that is, if above discriminant >= 0, then there exists a point along ray that also lies along sphere's surface)
 bool Sphere::intersect(const Ray& ray, Intersection& result) const {
-    Vec3 M = ray.origin - this->centroid;
+    Vec3 M = ray.origin - this->position_;
     float dDotM = Math::dot(ray.direction, M);
-    float discriminant = (dDotM * dDotM) - (Math::magnitudeSquared(M) - radius * radius);
+    float discriminant = (dDotM * dDotM) - (Math::magnitudeSquared(M) - radius_ * radius_);
     if (discriminant < 0.00f) {
         return false;
     }
@@ -32,21 +34,24 @@ bool Sphere::intersect(const Ray& ray, Intersection& result) const {
     }
     result.t      = closestT;
     result.point  = ray.origin + ray.direction * result.t;
-    result.normal = (result.point - this->centroid) / this->radius;
+    result.normal = (result.point - this->position_) / this->radius_;
     result.object = this;
     return true;
 }
 
-float Sphere::getRadius() const {
-    return radius;
+constexpr Vec3 Sphere::center() const {
+    return center_;
+}
+constexpr float Sphere::radius() const {
+    return radius_;
 }
 
-std::string Sphere::getDescription() const {
+std::string Sphere::description() const {
     std::stringstream ss;
     ss << "Sphere("
-         << "centroid:(" << getCentroid() << "),"
-         << "material:"  << getMaterial() << ","
-         << "radius:"    << getRadius()
+         << "position:(" << center()   << "),"
+         << "material:"  << material() << ","
+         << "radius:"    << radius()
        << ")";
     return ss.str();
 }
@@ -54,68 +59,74 @@ std::string Sphere::getDescription() const {
 
 Triangle::Triangle(const Vec3& vert0, const Vec3& vert1, const Vec3& vert2, const Material& material) {
     // note that base class members can only be initialized in the body and not our typical initializer list
-    this->material = material;
-    this->vert0 = vert0;
-    this->vert1 = vert1;
-    this->vert2 = vert2;
-    this->edge0 = vert1 - vert0;
-    this->edge1 = vert2 - vert1;
-    this->edge2 = vert0 - vert2;
-    this->centroid    = computeCentroid();
-    this->planeNormal = Math::normalize(Math::cross(edge0, edge1));
+    this->vert0_ = vert0;
+    this->vert1_ = vert1;
+    this->vert2_ = vert2;
+    this->edge0_ = vert1 - vert0;
+    this->edge1_ = vert2 - vert1;
+    this->edge2_ = vert0 - vert2;
+    this->planeNormal_ = Math::normalize(Math::cross(edge0_, edge1_));
+    this->center_ = computeCentroid();
+
+    this->material_ = material;
+    this->position_ = this->center_;
 }
 
 // given ray intersects triangle IFF given ray [X(t) = P + tD] intersects the plane [P.n = k] in a way such that
 // our intersection point is always to the LEFT side of EVERY edge
 // (aka our plane intersection point @[t = (k – P.n)/(D.n)] lies in between our triangle vertices)
 bool Triangle::intersect(const Ray& ray, Intersection& result) const {
-    float k = Math::dot(vert0, planeNormal);
-    float t = (k - Math::dot(ray.origin, planeNormal)) / Math::dot(ray.direction, planeNormal);
+    float k = Math::dot(vert0_, planeNormal_);
+    float t = (k - Math::dot(ray.origin, planeNormal_)) / Math::dot(ray.direction, planeNormal_);
     Vec3 pointIntersectingPlane = ray.origin + ray.direction * t;
-    if (isPointInTriangle(pointIntersectingPlane)) {
+    if (contains(pointIntersectingPlane)) {
         result.t      = t;
         result.point  = pointIntersectingPlane;
-        result.normal = planeNormal;
+        result.normal = planeNormal_;
         result.object = this;
         return true;
     }
     return false;
 }
 
-Vec3 Triangle::computeCentroid() const {
-    return Vec3((vert0.x + vert1.x + vert2.x) / 3.00f,
-                (vert0.y + vert1.y + vert2.y) / 3.00f,
-                (vert0.z + vert1.z + vert2.z) / 3.00f);
+constexpr Vec3 Triangle::vert0() const {
+    return vert0_;
 }
+constexpr Vec3 Triangle::vert1() const {
+    return vert1_;
+}
+constexpr Vec3 Triangle::vert2() const {
+    return vert2_;
+}
+constexpr Vec3 Triangle::planeNormal() const {
+    return planeNormal_;
+}
+constexpr Vec3 Triangle::center() const {
+    return center_;
+}
+
 // recall, a point lies in a triangle if..
 // (e0 x(R – P0)).n > 0 & (e1 x(R – P1)).n > 0 & (e2 x(R – P2)).n > 0
 // aka R is always to the LEFT side of EVERY edge
-bool Triangle::isPointInTriangle(const Vec3& point) const {
-    return (Math::dot(planeNormal, Math::cross(edge0, (point - vert0))) > 0.00f) &&
-           (Math::dot(planeNormal, Math::cross(edge1, (point - vert1))) > 0.00f) &&
-           (Math::dot(planeNormal, Math::cross(edge2, (point - vert2))) > 0.00f);
+constexpr bool Triangle::contains(const Vec3& point) const {
+    return (Math::dot(planeNormal_, Math::cross(edge0_, (point - vert0_))) > 0.00f) &&
+           (Math::dot(planeNormal_, Math::cross(edge1_, (point - vert1_))) > 0.00f) &&
+           (Math::dot(planeNormal_, Math::cross(edge2_, (point - vert2_))) > 0.00f);
 }
 
-Vec3 Triangle::getVert0() const {
-    return vert0;
-}
-Vec3 Triangle::getVert1() const {
-    return vert1;
-}
-Vec3 Triangle::getVert2() const {
-    return vert2;
-}
-Vec3 Triangle::getPlaneNormal() const {
-    return planeNormal;
+constexpr Vec3 Triangle::computeCentroid() const {
+    return Vec3((vert0_.x + vert1_.x + vert2_.x) / 3.00f,
+                (vert0_.y + vert1_.y + vert2_.y) / 3.00f,
+                (vert0_.z + vert1_.z + vert2_.z) / 3.00f);
 }
 
-std::string Triangle::getDescription() const {
+std::string Triangle::description() const {
     std::stringstream ss;
     ss << "Triangle("
-         << "centroid:("        << getCentroid()    << "),"
-         << "plane-normal:(v0:" << getPlaneNormal() << "),"
-         << "material:"         << getMaterial()    << ","
-         << "verts:[v0:(" << getVert0() << "),v1:(" << getVert1() << "),v2:(" << getVert2() << ")]"
+         << "position:("        << center()      << "),"
+         << "plane-normal:(v0:" << planeNormal() << "),"
+         << "material:"         << material()    << ","
+         << "verts:[v0:(" << vert0() << "),v1:(" << vert1() << "),v2:(" << vert2() << ")]"
        << ")";
     return ss.str();
 }

--- a/src/Objects.h
+++ b/src/Objects.h
@@ -25,7 +25,7 @@ inline std::ostream& operator<<(std::ostream& os, const IObject& object) {
 }
 
 
-class Sphere : public IObject {
+class Sphere final : public virtual IObject {
 private:
     float radius_;
     Vec3 center_;
@@ -40,7 +40,7 @@ public:
 };
 
 
-class Triangle : public IObject {
+class Triangle final : public virtual IObject {
 private:
     Vec3 vert0_;
     Vec3 vert1_;

--- a/src/Objects.h
+++ b/src/Objects.h
@@ -7,58 +7,62 @@
 // virtual base class for ANY renderable (via ray-tracing) object in a scene
 class IObject {
 protected:
-    Vec3 centroid{};
-    Material material{};
+    Vec3 position_{};
+    Material material_{};
 
 public:
     ~IObject() {}
 
     virtual bool intersect(const Ray& ray, Intersection& result) const = 0;
-    virtual std::string getDescription() const = 0;
-
-    Vec3     getCentroid() const { return centroid; }
-    Material getMaterial() const { return material; }
+    virtual std::string description() const = 0;
+    
+    constexpr Vec3 position() const  { return position_; }
+    constexpr const Material& material() const { return material_; }
 };
 inline std::ostream& operator<<(std::ostream& os, const IObject& object) {
-    os << object.getDescription();
+    os << object.description();
     return os;
 }
 
 
 class Sphere : public IObject {
 private:
-    float radius;
+    float radius_;
+    Vec3 center_;
 
 public:
     Sphere(const Vec3& center, float radius, const Material& material);
     virtual bool intersect(const Ray& ray, Intersection& result) const override;
-    virtual std::string getDescription() const override;
-
-    float getRadius() const;
+    virtual std::string description() const override;
+    
+    constexpr float radius() const;
+    constexpr Vec3 center()  const;
 };
 
 
 class Triangle : public IObject {
 private:
-    Vec3 vert0;
-    Vec3 vert1;
-    Vec3 vert2;
-    Vec3 edge0;
-    Vec3 edge1;
-    Vec3 edge2;
-    Vec3 planeNormal;
-    
+    Vec3 vert0_;
+    Vec3 vert1_;
+    Vec3 vert2_;
+    Vec3 edge0_;
+    Vec3 edge1_;
+    Vec3 edge2_;
+    Vec3 planeNormal_;
+    Vec3 center_;
+
 public:
     Triangle(const Vec3& vert0, const Vec3& vert1, const Vec3& vert2, const Material& material);
     virtual bool intersect(const Ray& ray, Intersection& result) const override;
-    virtual std::string getDescription() const override;
-
-    Vec3 getVert0()       const;
-    Vec3 getVert1()       const;
-    Vec3 getVert2()       const;
-    Vec3 getPlaneNormal() const;
+    virtual std::string description() const override;
+    
+    constexpr Vec3 vert0()       const;
+    constexpr Vec3 vert1()       const;
+    constexpr Vec3 vert2()       const;
+    constexpr Vec3 planeNormal() const;
+    constexpr Vec3 center()      const;
+    constexpr bool contains(const Vec3& point) const;
 
 private:
-    Vec3 computeCentroid() const;
-    bool isPointInTriangle(const Vec3& point) const;
+    constexpr Vec3 computeCentroid() const;
 };

--- a/src/StopWatch.hpp
+++ b/src/StopWatch.hpp
@@ -5,44 +5,46 @@
 
 class StopWatch {
 private:
-    std::optional<double> _startTime;
-    std::optional<double> _stopTime;
+    std::optional<double> startTime_;
+    std::optional<double> stopTime_;
     
-    static double getCurrentTime() { return omp_get_wtime(); }
-    static double duration(double start, double end) { return end - start; }
+    static double currentTime() { return omp_get_wtime(); }
+
 public:
-    StopWatch() :
-        _startTime(std::nullopt),
-        _stopTime(std::nullopt)
+    StopWatch()
+        : startTime_(std::nullopt),
+          stopTime_ (std::nullopt)
     {}
+
     void reset() {
-        _startTime = std::nullopt;
-        _stopTime  = std::nullopt;
+        startTime_ = std::nullopt;
+        stopTime_  = std::nullopt;
     }
     void start() {
         if (!isRunning()) {
-            _startTime = getCurrentTime();
-            _stopTime  = std::nullopt;
+            startTime_ = currentTime();
+            stopTime_ = std::nullopt;
         }
     }
     void stop() {
         if (isRunning()) {
-            _stopTime = getCurrentTime();
+            stopTime_ = currentTime();
         }
     }
 
     bool isRunning() const {
-        return _startTime.has_value() && !_stopTime.has_value();
+        return startTime_.has_value() && !stopTime_.has_value();
     }
     bool isFinished() const {
-        return _startTime.has_value() && _stopTime.has_value();
+        return startTime_.has_value() && stopTime_.has_value();
     }
+    // compute time since start and now (or since time last stopped)
     double elapsedTime() const {
         if (isRunning()) {
-            return getCurrentTime() - _startTime.value();
+            return currentTime() - startTime_.value();
         }
         if (isFinished()) {
-            return _stopTime.value() - _startTime.value();
+            return stopTime_.value() - startTime_.value();
         }
         return 0;
     }

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -134,13 +134,13 @@ bool Tracer::findNearestIntersection(const Scene& scene, const Ray& ray, Interse
 }
 // check if there exists another object blocking light from reaching our hit-point
 bool Tracer::isInShadow(const Intersection& intersection, const ILight& light, const Scene& scene) const {
-    Ray shadowRay{ intersection.point + (shadowBias_ * intersection.normal), Math::direction(intersection.point, light.getPosition()) };
-    float distanceToLight = Math::distance(shadowRay.origin, light.getPosition());
+    Ray shadowRay{ intersection.point + (shadowBias_ * intersection.normal), Math::direction(intersection.point, light.position()) };
+    float distanceToLight = Math::distance(shadowRay.origin, light.position());
     for (size_t index = 0; index < scene.getNumObjects(); index++) {
         Intersection occlusion;
         if (scene.getObject(index).intersect(shadowRay, occlusion) &&
                 occlusion.object != intersection.object &&
-                Math::distance(occlusion.point, light.getPosition()) < distanceToLight) {
+                Math::distance(occlusion.point, light.position()) < distanceToLight) {
             return true;
         }
     }
@@ -148,7 +148,7 @@ bool Tracer::isInShadow(const Intersection& intersection, const ILight& light, c
 }
 
 Color Tracer::computeDiffuseColor(const Intersection& intersection, const ILight& light) const {
-    Vec3 directionToLight = Math::direction(intersection.point, light.getPosition());
+    Vec3 directionToLight = Math::direction(intersection.point, light.position());
 
     const Material surfaceMaterial = intersection.object->material();
     float strengthAtLightAngle = Math::max(0.00f, Math::dot(intersection.normal, directionToLight));
@@ -157,7 +157,7 @@ Color Tracer::computeDiffuseColor(const Intersection& intersection, const ILight
 
 Color Tracer::computeSpecularColor(const Intersection& intersection, const ILight& light, const Camera& renderCam) const {
     Vec3 directionToCam = Math::direction(intersection.point, renderCam.getPosition());
-    Vec3 halfwayVec = Math::normalize(directionToCam + light.getPosition());
+    Vec3 halfwayVec = Math::normalize(directionToCam + light.position());
 
     const Material surfaceMaterial = intersection.object->material();
     float strengthAtCamAngle = Math::max(0.00f, Math::dot(intersection.normal, halfwayVec));

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -69,11 +69,11 @@ Color Tracer::traceRay(const Camera& renderCam, const Scene& scene, const Ray& r
     }
 
     Color reflectedColor{ 0, 0, 0 };
-    if (intersection.object->getMaterial().getReflectivity() > 0.00f) {
+    if (intersection.object->material().reflectivity() > 0.00f) {
         reflectedColor = traceRay(renderCam, scene, reflectRay(ray, intersection), iteration + 1);
     }
     
-    Color nonReflectedColor = intersection.object->getMaterial().getAmbientColor();
+    Color nonReflectedColor = intersection.object->material().ambientColor();
     for (size_t index = 0; index < scene.getNumLights(); index++) {
        const ILight& light = scene.getLight(index);
        if (!isInShadow(intersection, light, scene)) {
@@ -87,8 +87,8 @@ Color Tracer::traceRay(const Camera& renderCam, const Scene& scene, const Ray& r
     }
     
     // blend intrinsic and reflected color using our light and intersected object
-    return (intersection.object->getMaterial().getIntrinsity()   * nonReflectedColor) + 
-           (intersection.object->getMaterial().getReflectivity() * reflectedColor);
+    return (intersection.object->material().intrinsity()   * nonReflectedColor) + 
+           (intersection.object->material().reflectivity() * reflectedColor);
 }
 
 // reflect our ray using a slight direction offset to avoid infinite reflections
@@ -134,18 +134,18 @@ bool Tracer::isInShadow(const Intersection& intersection, const ILight& light, c
 Color Tracer::computeDiffuseColor(const Intersection& intersection, const ILight& light) const {
     Vec3 directionToLight = Math::direction(intersection.point, light.getPosition());
 
-    const Material surfaceMaterial = intersection.object->getMaterial();
+    const Material surfaceMaterial = intersection.object->material();
     float strengthAtLightAngle = Math::max(0.00f, Math::dot(intersection.normal, directionToLight));
-    return strengthAtLightAngle * surfaceMaterial.getDiffuseColor();
+    return strengthAtLightAngle * surfaceMaterial.diffuseColor();
 }
 
 Color Tracer::computeSpecularColor(const Intersection& intersection, const ILight& light, const Camera& renderCam) const {
     Vec3 directionToCam = Math::direction(intersection.point, renderCam.getPosition());
     Vec3 halfwayVec = Math::normalize(directionToCam + light.getPosition());
 
-    const Material surfaceMaterial = intersection.object->getMaterial();
+    const Material surfaceMaterial = intersection.object->material();
     float strengthAtCamAngle = Math::max(0.00f, Math::dot(intersection.normal, halfwayVec));
-    return Math::pow(strengthAtCamAngle, surfaceMaterial.getShininess()) * surfaceMaterial.getSpecularColor();
+    return Math::pow(strengthAtCamAngle, surfaceMaterial.shininess()) * surfaceMaterial.specularColor();
 }
 
 std::ostream& operator<<(std::ostream& os, const Tracer& tracer) {

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -9,28 +9,44 @@
 #include <omp.h>
 
 
-Tracer::Tracer() :
-    shadowColor      (DEFAULT_SHADOW_COLOR),
-    backgroundColor  (DEFAULT_BACKGROUND_COLOR),
-    shadowBias       (DEFAULT_SHADOW_BIAS),
-    reflectionBias   (DEFAULT_REFLECTION_BIAS),
-    maxNumReflections(DEFAULT_MAX_NUM_REFLECTIONS)
+Tracer::Tracer()
+    : shadowColor_      (DEFAULT_SHADOW_COLOR),
+      backgroundColor_  (DEFAULT_BACKGROUND_COLOR),
+      shadowBias_       (DEFAULT_SHADOW_BIAS),
+      reflectionBias_   (DEFAULT_REFLECTION_BIAS),
+      maxNumReflections_(DEFAULT_MAX_NUM_REFLECTIONS)
 {}
 
 void Tracer::setShadowColor(const Color& shadowColor) {
-    this->shadowColor = shadowColor;
+    this->shadowColor_ = shadowColor;
 }
 void Tracer::setBackgroundColor(const Color& backgroundColor) {
-    this->backgroundColor = backgroundColor;
+    this->backgroundColor_ = backgroundColor;
 }
 void Tracer::setShadowBias(float shadowBias) {
-    this->shadowBias = shadowBias;
+    this->shadowBias_ = shadowBias;
 }
 void Tracer::setReflectionBias(float reflectionBias) {
-    this->reflectionBias = reflectionBias;
+    this->reflectionBias_ = reflectionBias;
 }
 void Tracer::setMaxNumReflections(size_t maxNumReflections) {
-    this->maxNumReflections = maxNumReflections;
+    this->maxNumReflections_ = maxNumReflections;
+}
+
+Color Tracer::shadowColor() const {
+    return shadowColor_;
+}
+Color Tracer::backgroundColor() const {
+    return backgroundColor_;
+}
+float Tracer::shadowBias() const {
+    return shadowBias_;
+}
+float Tracer::reflectionBias() const {
+    return reflectionBias_;
+}
+size_t Tracer::maxNumReflections() const {
+    return maxNumReflections_;
 }
 
 // for each pixel in buffer shoot ray from camera position to its projected point on the image plane,
@@ -59,13 +75,13 @@ void Tracer::trace(const Camera& renderCam, const Scene& scene, FrameBuffer& fra
 
 // todo: account for near and far clip culling (probably need to determine z dist pf object to camera and clamp on that)
 Color Tracer::traceRay(const Camera& renderCam, const Scene& scene, const Ray& ray, size_t iteration=0) const {
-    if (iteration >= maxNumReflections) {
+    if (iteration >= maxNumReflections_) {
         return Color{ 0, 0, 0 };
     }
 
     Intersection intersection{};
     if (!findNearestIntersection(scene, ray, intersection)) {
-        return backgroundColor;
+        return backgroundColor_;
     }
 
     Color reflectedColor{ 0, 0, 0 };
@@ -82,7 +98,7 @@ Color Tracer::traceRay(const Camera& renderCam, const Scene& scene, const Ray& r
            Color lightIntensityAtPoint = light.computeIntensityAtPoint(intersection.point);
            nonReflectedColor = nonReflectedColor + lightIntensityAtPoint * (diffuse + specular);
        } else {
-           nonReflectedColor = nonReflectedColor + shadowColor;
+           nonReflectedColor = nonReflectedColor + shadowColor_;
        }
     }
     
@@ -96,7 +112,7 @@ Ray Tracer::reflectRay(const Ray& ray, const Intersection& intersection) const {
     Vec3 reflectedDirection = Math::normalize(
         (-1 * ray.direction) + (2 * Math::dot(ray.direction, intersection.normal) * intersection.normal)
     );
-    return Ray(intersection.point + (reflectionBias * reflectedDirection), reflectedDirection);
+    return Ray(intersection.point + (reflectionBias_ * reflectedDirection), reflectedDirection);
 }
 bool Tracer::findNearestIntersection(const Scene& scene, const Ray& ray, Intersection& result) const {
     float tClosest = Math::INF;
@@ -118,7 +134,7 @@ bool Tracer::findNearestIntersection(const Scene& scene, const Ray& ray, Interse
 }
 // check if there exists another object blocking light from reaching our hit-point
 bool Tracer::isInShadow(const Intersection& intersection, const ILight& light, const Scene& scene) const {
-    Ray shadowRay{ intersection.point + (shadowBias * intersection.normal), Math::direction(intersection.point, light.getPosition()) };
+    Ray shadowRay{ intersection.point + (shadowBias_ * intersection.normal), Math::direction(intersection.point, light.getPosition()) };
     float distanceToLight = Math::distance(shadowRay.origin, light.getPosition());
     for (size_t index = 0; index < scene.getNumObjects(); index++) {
         Intersection occlusion;
@@ -150,11 +166,11 @@ Color Tracer::computeSpecularColor(const Intersection& intersection, const ILigh
 
 std::ostream& operator<<(std::ostream& os, const Tracer& tracer) {
     os << "Tracer("
-         << "shadow-color:("       << tracer.getShadowColor()       << "),"
-         << "background-color:("   << tracer.getBackgroundColor()   << "),"
-         << "shadow-bias:"         << tracer.getShadowBias()        << ","
-         << "reflection-bias:"     << tracer.getReflectionBias()    << ","
-         << "max-num-reflections:" << tracer.getMaxNumReflections()
+         << "shadow-color:("       << tracer.shadowColor()       << "),"
+         << "background-color:("   << tracer.backgroundColor()   << "),"
+         << "shadow-bias:"         << tracer.shadowBias()        << ","
+         << "reflection-bias:"     << tracer.reflectionBias()    << ","
+         << "max-num-reflections:" << tracer.maxNumReflections()
        << ")";
     return os;
 }

--- a/src/Tracer.cpp
+++ b/src/Tracer.cpp
@@ -56,8 +56,8 @@ void Tracer::trace(const Camera& renderCam, const Scene& scene, FrameBuffer& fra
     const int height       = static_cast<int>(frameBuffer.height());
     const float invWidth   = 1.00f / width;
     const float invHeight  = 1.00f / height;
-    const float nearZ      = renderCam.getNearClip();
-    const Vec3 eyePosition = renderCam.getPosition();
+    const float nearZ      = renderCam.nearClip();
+    const Vec3 eyePosition = renderCam.position();
     #pragma omp for schedule(dynamic)
     for (int row = 0; row < height; row++) {
         for (int col = 0; col < width; col++) {
@@ -156,7 +156,7 @@ Color Tracer::computeDiffuseColor(const Intersection& intersection, const ILight
 }
 
 Color Tracer::computeSpecularColor(const Intersection& intersection, const ILight& light, const Camera& renderCam) const {
-    Vec3 directionToCam = Math::direction(intersection.point, renderCam.getPosition());
+    Vec3 directionToCam = Math::direction(intersection.point, renderCam.position());
     Vec3 halfwayVec = Math::normalize(directionToCam + light.position());
 
     const Material surfaceMaterial = intersection.object->material();

--- a/src/Tracer.h
+++ b/src/Tracer.h
@@ -11,11 +11,11 @@
 
 class Tracer {
 private:
-    Color shadowColor;
-    Color backgroundColor;
-    float shadowBias;
-    float reflectionBias;
-    size_t maxNumReflections;
+    Color shadowColor_;
+    Color backgroundColor_;
+    float shadowBias_;
+    float reflectionBias_;
+    size_t maxNumReflections_;
 
     static constexpr Color DEFAULT_SHADOW_COLOR     { 0.125f, 0.125f, 0.125f };
     static constexpr Color DEFAULT_BACKGROUND_COLOR { 0.500f, 0.500f, 0.500f };
@@ -27,17 +27,18 @@ private:
 public:
     Tracer();
     void trace(const Camera&, const Scene&, FrameBuffer&);
-    void setShadowColor(const Color&);
-    void setBackgroundColor(const Color&);
-    void setShadowBias(float);
-    void setReflectionBias(float);
-    void setMaxNumReflections(size_t);
-    
-    Color getShadowColor()        const { return shadowColor;       }
-    Color getBackgroundColor()    const { return backgroundColor;   }
-    float getShadowBias()         const { return shadowBias;        }
-    float getReflectionBias()     const { return reflectionBias;    }
-    size_t getMaxNumReflections() const { return maxNumReflections; }
+
+    void setShadowColor(const Color& shadowColor);
+    void setBackgroundColor(const Color& backgroundColor);
+    void setShadowBias(float shadowBias);
+    void setReflectionBias(float reflectionBias);
+    void setMaxNumReflections(size_t maxNumReflections);
+
+    Color shadowColor()        const;
+    Color backgroundColor()    const;
+    float shadowBias()         const;
+    float reflectionBias()     const;
+    size_t maxNumReflections() const;
 
 private:
     Color traceRay(const Camera&, const Scene&, const Ray&, size_t) const;


### PR DESCRIPTION
# Standardize Formatting - Part 2
Standardizes naming, inline, and accessor/mutator convention, all fields now are consistent with the C++ convenience of a trailer underscore for the field, accessed via constexpr method of the same name without the underscore.