### PR TITLE
Fix potential errors on access and deletion of objects in scene

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -53,9 +53,9 @@ int main() {
     tracer.setShadowBias(0.02f);
     tracer.setReflectionBias(0.08f);
 
-    Vec3 eyeTarget{ 0, 50, 0 };
-    Vec3 sceneOrigin{ 0, 0, 0 };
-    Scene scene = createSimpleScene(sceneOrigin);
+    const Vec3 eyeTarget{ 0, 50, 0 };
+    const Vec3 sceneOrigin{ 0, 0, 0 };
+    const Scene scene = createSimpleScene(sceneOrigin);
     FrameBuffer frameBuffer{ CommonResolutions::HD_4K };
     Camera frontCam    = createCamera(eyeTarget + Vec3(0,   0,  50), 120.00f, 0.50f, eyeTarget, frameBuffer.aspectRatio());
     Camera frontTopCam = createCamera(eyeTarget + Vec3(0,  50,  25), 120.00f, 0.50f, eyeTarget, frameBuffer.aspectRatio());

--- a/src/Objects.h
+++ b/src/Objects.h
@@ -11,8 +11,7 @@ protected:
     Material material_{};
 
 public:
-    ~IObject() {}
-
+    virtual ~IObject() = default;
     virtual bool intersect(const Ray& ray, Intersection& result) const = 0;
     virtual std::string description() const = 0;
     

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -2,6 +2,7 @@
 #include "Lights.h"
 #include "Objects.h"
 #include <vector>
+#include <assert.h>
 
 
 Scene::Scene()
@@ -10,13 +11,13 @@ Scene::Scene()
 {}
 
 void Scene::addLight(PointLight light) {
-    lights.push_back(std::move(std::make_unique<PointLight>(light)));
+    lights.push_back(std::make_unique<PointLight>(std::move(light)));
 }
 void Scene::addSceneObject(Sphere object) {
-    objects.push_back(std::move(std::make_unique<Sphere>(object)));
+    objects.push_back(std::make_unique<Sphere>(std::move(object)));
 }
 void Scene::addSceneObject(Triangle object) {
-    objects.push_back(std::move(std::make_unique<Triangle>(object)));
+    objects.push_back(std::make_unique<Triangle>(std::move(object)));
 }
 
 size_t Scene::getNumLights() const {
@@ -26,9 +27,11 @@ size_t Scene::getNumObjects() const {
     return objects.size();
 }
 const ILight& Scene::getLight(size_t index) const {
+    assert(index >= 0 && index < lights.size());
     return *lights[index].get();
 }
 const IObject& Scene::getObject(size_t index) const {
+    assert(index >= 0 && index < objects.size());
     return *objects[index].get();
 }
 


### PR DESCRIPTION
# Fix potential errors on access and deletion of objects in scene
Found a bug that ocasional occurs at the end of main when destructors are called, where delete is called on a base-class (unique) pointer that has no virtual destructor, which is undefined behavior, which explains why the error did not occur every time.

It's now fixed by making the destructor of IObject virtual, just like ILights has. Must have overlooked it somehow.

Also, added a few related preventive measures, namely marking scene and points constant in main(), asserting out of range indices when accessing scene components, and moving object _before_ constructor unique_ptrs instead of after.

# Full Changelog
* Main: Make targets, origin, and scene all const
* Objects: Make object destructors virtual by default (like ILight does)
* Scene: Prevent move and index errors by moving before allocation and checking indices