### PR TITLE
Add inplace operators for colors and vectors

### DIFF
--- a/src/Color.hpp
+++ b/src/Color.hpp
@@ -17,6 +17,10 @@ private:
     static constexpr unsigned char extractGreenByte(unsigned int hex) { return static_cast<unsigned char>((hex >> 8)  & 0xff); }
     static constexpr unsigned char extractBlueByte(unsigned int hex)  { return static_cast<unsigned char>(hex & 0xff);         }
 
+    inline constexpr void setClamped(float r, float g, float b) {
+        this->r = Math::clamp01(r); this->g = Math::clamp01(g); this->b = Math::clamp01(b);
+    }
+
 public:
     float r;
     float g;
@@ -40,11 +44,6 @@ public:
     inline constexpr Color& operator*=(const Color& rhs) { setClamped(r * rhs.r, g * rhs.g, b * rhs.b); return *this; }
     inline constexpr Color& operator*=(float        rhs) { setClamped(r * rhs,   g * rhs,   b * rhs);   return *this; }
     inline constexpr Color& operator/=(float        rhs) { setClamped(r / rhs,   g / rhs,   b / rhs);   return *this; }
-
-private:
-    inline constexpr void setClamped(float r, float g, float b) {
-        this->r = Math::clamp01(r); this->g = Math::clamp01(g); this->b = Math::clamp01(b);
-    }
 };
 inline constexpr Color operator+(const Color& lhs, const Color& rhs)  { return Color(lhs.r + rhs.r, lhs.g + rhs.g, lhs.b + rhs.b);    }
 inline constexpr Color operator-(const Color& lhs, const Color& rhs)  { return Color(lhs.r - rhs.r, lhs.g - rhs.g, lhs.b - rhs.b);    }

--- a/src/Color.hpp
+++ b/src/Color.hpp
@@ -34,14 +34,25 @@ public:
                ( (0xff & static_cast<unsigned char>(floatToInt(g))) << 8  ) |
                ( (0xff & static_cast<unsigned char>(floatToInt(b)))       );
     }
+
+    inline constexpr Color& operator+=(const Color& rhs) { setClamped(r + rhs.r, g + rhs.g, b + rhs.b); return *this; }
+    inline constexpr Color& operator-=(const Color& rhs) { setClamped(r - rhs.r, g - rhs.g, b - rhs.b); return *this; }
+    inline constexpr Color& operator*=(const Color& rhs) { setClamped(r * rhs.r, g * rhs.g, b * rhs.b); return *this; }
+    inline constexpr Color& operator*=(float        rhs) { setClamped(r * rhs,   g * rhs,   b * rhs);   return *this; }
+    inline constexpr Color& operator/=(float        rhs) { setClamped(r / rhs,   g / rhs,   b / rhs);   return *this; }
+
+private:
+    inline constexpr void setClamped(float r, float g, float b) {
+        this->r = Math::clamp01(r); this->g = Math::clamp01(g); this->b = Math::clamp01(b);
+    }
 };
-inline constexpr Color operator+(const Color& lhs, const Color& rhs)  { return Color(lhs.r + rhs.r, lhs.g + rhs.g, lhs.b + rhs.b); }
-inline constexpr Color operator-(const Color& lhs, const Color& rhs)  { return Color(lhs.r - rhs.r, lhs.g - rhs.g, lhs.b - rhs.b); }
-inline constexpr Color operator*(const Color& lhs, const Color& rhs)  { return Color(lhs.r * rhs.r, lhs.g * rhs.g, lhs.b * rhs.b); }
-inline constexpr Color operator*(float        lhs, const Color& rhs)  { return Color(lhs   * rhs.r, lhs   * rhs.g, lhs   * rhs.b); }
-inline constexpr Color operator*(const Color& lhs, float        rhs)  { return Color(lhs.r * rhs,   lhs.g * rhs,   lhs.b * rhs);   }
-inline constexpr Color operator/(const Color& lhs, float        rhs)  { return Color(lhs.r / rhs,   lhs.g / rhs,   lhs.b / rhs);   }
-inline std::ostream& operator<<(std::ostream& os, const Color& intensity) { os << intensity.r << "," << intensity.g << "," << intensity.b; return os; }
+inline constexpr Color operator+(const Color& lhs, const Color& rhs)  { return Color(lhs.r + rhs.r, lhs.g + rhs.g, lhs.b + rhs.b);    }
+inline constexpr Color operator-(const Color& lhs, const Color& rhs)  { return Color(lhs.r - rhs.r, lhs.g - rhs.g, lhs.b - rhs.b);    }
+inline constexpr Color operator*(const Color& lhs, const Color& rhs)  { return Color(lhs.r * rhs.r, lhs.g * rhs.g, lhs.b * rhs.b);    }
+inline constexpr Color operator*(float        lhs, const Color& rhs)  { return Color(lhs   * rhs.r, lhs   * rhs.g, lhs   * rhs.b);    }
+inline constexpr Color operator*(const Color& lhs, float        rhs)  { return Color(lhs.r * rhs,   lhs.g * rhs,   lhs.b * rhs);      }
+inline constexpr Color operator/(const Color& lhs, float        rhs)  { return Color(lhs.r / rhs,   lhs.g / rhs,   lhs.b / rhs);      }
+inline std::ostream& operator<<(std::ostream& os, const Color& color) { os << color.r << "," << color.g << "," << color.b; return os; }
 
 
 namespace Palette {

--- a/src/Math.hpp
+++ b/src/Math.hpp
@@ -21,10 +21,10 @@ struct Vec2 {
     static constexpr Vec2 zero()  { return Vec2( 0,  0); };
     static constexpr Vec2 one()   { return Vec2( 1,  1); };
     
-    constexpr Vec2& operator+=(const Vec2& rhs) { x += rhs.x;  y += rhs.y; return *this; }
-    constexpr Vec2& operator-=(const Vec2& rhs) { x -= rhs.x;  y -= rhs.y; return *this; }
-    constexpr Vec2& operator*=(float       rhs) { x *= rhs;    y *= rhs;   return *this; }
-    constexpr Vec2& operator/=(float       rhs) { x /= rhs;    y /= rhs;   return *this; }
+    inline constexpr Vec2& operator+=(const Vec2& rhs) { x += rhs.x;  y += rhs.y; return *this; }
+    inline constexpr Vec2& operator-=(const Vec2& rhs) { x -= rhs.x;  y -= rhs.y; return *this; }
+    inline constexpr Vec2& operator*=(float       rhs) { x *= rhs;    y *= rhs;   return *this; }
+    inline constexpr Vec2& operator/=(float       rhs) { x /= rhs;    y /= rhs;   return *this; }
 };
 inline constexpr Vec2 operator+(const Vec2& lhs,  const Vec2& rhs) { return Vec2(lhs.x + rhs.x, lhs.y + rhs.y); }
 inline constexpr Vec2 operator-(const Vec2& lhs,  const Vec2& rhs) { return Vec2(lhs.x - rhs.x, lhs.y - rhs.y); }
@@ -52,10 +52,10 @@ struct Vec3 {
     static constexpr Vec3 right()  { return Vec3( 1,  0,  0); };
     static constexpr Vec3 left()   { return Vec3(-1,  0,  0); };
     
-    constexpr Vec3& operator+=(const Vec3& rhs) { x += rhs.x;  y += rhs.y; z += rhs.z; return *this; }
-    constexpr Vec3& operator-=(const Vec3& rhs) { x -= rhs.x;  y -= rhs.y; z -= rhs.z; return *this; }
-    constexpr Vec3& operator*=(float       rhs) { x *= rhs;    y *= rhs;   z *= rhs;   return *this; }
-    constexpr Vec3& operator/=(float       rhs) { x /= rhs;    y /= rhs;   z /= rhs;   return *this; }
+    inline constexpr Vec3& operator+=(const Vec3& rhs) { x += rhs.x;  y += rhs.y; z += rhs.z; return *this; }
+    inline constexpr Vec3& operator-=(const Vec3& rhs) { x -= rhs.x;  y -= rhs.y; z -= rhs.z; return *this; }
+    inline constexpr Vec3& operator*=(float       rhs) { x *= rhs;    y *= rhs;   z *= rhs;   return *this; }
+    inline constexpr Vec3& operator/=(float       rhs) { x /= rhs;    y /= rhs;   z /= rhs;   return *this; }
 };
 inline constexpr Vec3 operator+(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z); }
 inline constexpr Vec3 operator-(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z); }
@@ -86,10 +86,10 @@ inline constexpr float abs(float a)            { return a <= 0.00f? -a : a; }
 inline constexpr float min(float a, float b)   { return a <= b?      a : b; }
 inline constexpr float max(float a, float b)   { return a >= b?      a : b; }
 
-constexpr float INF = std::numeric_limits<float>::infinity();
-constexpr float PI   = 3.14159265358979323846f;
-constexpr float PI_2 = 1.57079632679489661923f;
-constexpr float PI_4 = 0.78539816339744830962f;
+inline constexpr float INF  = std::numeric_limits<float>::infinity();
+inline constexpr float PI   = 3.14159265358979323846f;
+inline constexpr float PI_2 = 1.57079632679489661923f;
+inline constexpr float PI_4 = 0.78539816339744830962f;
 inline constexpr float radToDeg(float radians) { return radians * (180.00f / PI);      }
 inline constexpr float degToRad(float degrees) { return degrees * (PI      / 180.00f); }
 inline float sin(float degrees)                { return std::sinf(degToRad(degrees));  }

--- a/src/Math.hpp
+++ b/src/Math.hpp
@@ -20,6 +20,11 @@ struct Vec2 {
     static constexpr Vec2 left()  { return Vec2(-1,  0); };
     static constexpr Vec2 zero()  { return Vec2( 0,  0); };
     static constexpr Vec2 one()   { return Vec2( 1,  1); };
+    
+    constexpr Vec2& operator+=(const Vec2& rhs) { x += rhs.x;  y += rhs.y; return *this; }
+    constexpr Vec2& operator-=(const Vec2& rhs) { x -= rhs.x;  y -= rhs.y; return *this; }
+    constexpr Vec2& operator*=(float       rhs) { x *= rhs;    y *= rhs;   return *this; }
+    constexpr Vec2& operator/=(float       rhs) { x /= rhs;    y /= rhs;   return *this; }
 };
 inline constexpr Vec2 operator+(const Vec2& lhs,  const Vec2& rhs) { return Vec2(lhs.x + rhs.x, lhs.y + rhs.y); }
 inline constexpr Vec2 operator-(const Vec2& lhs,  const Vec2& rhs) { return Vec2(lhs.x - rhs.x, lhs.y - rhs.y); }
@@ -46,12 +51,17 @@ struct Vec3 {
     static constexpr Vec3 down()   { return Vec3( 0, -1,  0); };
     static constexpr Vec3 right()  { return Vec3( 1,  0,  0); };
     static constexpr Vec3 left()   { return Vec3(-1,  0,  0); };
+    
+    constexpr Vec3& operator+=(const Vec3& rhs) { x += rhs.x;  y += rhs.y; z += rhs.z; return *this; }
+    constexpr Vec3& operator-=(const Vec3& rhs) { x -= rhs.x;  y -= rhs.y; z -= rhs.z; return *this; }
+    constexpr Vec3& operator*=(float       rhs) { x *= rhs;    y *= rhs;   z *= rhs;   return *this; }
+    constexpr Vec3& operator/=(float       rhs) { x /= rhs;    y /= rhs;   z /= rhs;   return *this; }
 };
 inline constexpr Vec3 operator+(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z); }
 inline constexpr Vec3 operator-(const Vec3& lhs,  const Vec3& rhs) { return Vec3(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z); }
-inline constexpr Vec3 operator*(float       lhs,  const Vec3& rhs) { return Vec3(lhs   * rhs.x, lhs   * rhs.y, lhs   * rhs.z); }
-inline constexpr Vec3 operator*(const Vec3& lhs,  float       rhs) { return Vec3(lhs.x * rhs,   lhs.y * rhs,   lhs.z * rhs);   }
 inline constexpr Vec3 operator/(const Vec3& lhs,  float       rhs) { return Vec3(lhs.x / rhs,   lhs.y / rhs,   lhs.z / rhs);   }
+inline constexpr Vec3 operator*(const Vec3& lhs,  float       rhs) { return Vec3(lhs.x * rhs,   lhs.y * rhs,   lhs.z * rhs);   }
+inline constexpr Vec3 operator*(float       lhs,  const Vec3& rhs) { return Vec3(lhs   * rhs.x, lhs   * rhs.y, lhs   * rhs.z); }
 inline std::ostream& operator<<(std::ostream& os, const Vec3& vec) { os << vec.x << "," << vec.y << "," << vec.z; return os;   }
 
 


### PR DESCRIPTION
# Add inplace operators for colors and vectors
Overload +=, -=, /=, *= where appropriate for structs Vec2, Vec3, Color.
These were inconsistently missing before, and given that +, -, /, * were all defined, and that usage of the inplace assignments would be convenient for usage in tracer class, etc, I decided to make this trivial addition today.