### PR TITLE
App: Log output file info before, during, and after file writing

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -38,7 +38,6 @@ App::App(Scene&& scene, const AppOptions& options)
     if (options_.logInfo) {
         std::cout << Text::padSides(" Configuring App ", '*', 80) << "\n";
         std::cout << options_ << "\n\n";
-        std::cout << *this;
     }
     rayTracer_.setBias(options.rayTracingBias);
     rayTracer_.setMaxNumReflections(options.rayTracingReflectionLimit);

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -56,7 +56,7 @@ App::App(Scene&& scene, const AppOptions& options)
 
 void App::run() {
     if (options_.logInfo) {
-        std::cout << "\n" << Text::padSides(" Tracing `" + options_.imageOutputFile + "` ", '*', 80) << "\n";
+        std::cout << "\n" << Text::padSides(" Tracing `" + Files::fileName(options_.imageOutputFile) + "` ", '*', 80) << "\n";
 
         std::cout << "Tracing started...";
         stopWatch_.start();
@@ -66,12 +66,12 @@ void App::run() {
         
         std::cout << "Writing file started...";
         stopWatch_.start();
-        Files::writePpmWithGammaCorrection(frameBuffer_, options_.imageOutputFile, options_.imageOutputGamma);
+        Files::writePpmWithGammaCorrection(options_.imageOutputFile, frameBuffer_, options_.imageOutputGamma);
         stopWatch_.stop();
         std::cout << "finished in " << stopWatch_.elapsedTime() << " seconds" << "\n";
     } else {
         rayTracer_.traceScene(camera_, scene_, frameBuffer_);
-        Files::writePpmWithGammaCorrection(frameBuffer_, options_.imageOutputFile, options_.imageOutputGamma);
+        Files::writePpmWithGammaCorrection(options_.imageOutputFile, frameBuffer_, options_.imageOutputGamma);
     }
 }
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -35,6 +35,8 @@ App::App(Scene&& scene, const AppOptions& options)
       camera_     (),
       rayTracer_  (),
       frameBuffer_(options.imageOutputSize) {
+    // preferably, we'd using a logging framework or custom logger,
+    // but writing directly console will suffice for this class for now
     if (options_.logInfo) {
         std::cout << Text::padSides(" Configuring App ", '*', 80) << "\n";
         std::cout << options_ << "\n\n";
@@ -69,6 +71,8 @@ void App::run() {
         Files::writePpmWithGammaCorrection(options_.imageOutputFile, frameBuffer_, options_.imageOutputGamma);
         stopWatch_.stop();
         std::cout << "finished in " << stopWatch_.elapsedTime() << " seconds" << "\n";
+
+        std::cout << "output saved to filepath at " << Files::resolveAbsolutePath(options_.imageOutputFile) << "\n";
     } else {
         rayTracer_.traceScene(camera_, scene_, frameBuffer_);
         Files::writePpmWithGammaCorrection(options_.imageOutputFile, frameBuffer_, options_.imageOutputGamma);

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -12,7 +12,7 @@ std::ostream& operator<<(std::ostream& os, const AppOptions& appOptions) {
            << "logInfo:" << appOptions.logInfo          << ","
            << "gamma:"   << appOptions.imageOutputGamma << ","
            << "file:\'"  << appOptions.imageOutputFile  << "\',"
-           << "size:("    << appOptions.imageOutputSize << ")}, "
+           << "size:("   << appOptions.imageOutputSize  << ")}, "
          << "RayTracing{"
            << "bias:"             << appOptions.rayTracingBias            << ","
            << "reflection-limit:" << appOptions.rayTracingReflectionLimit << ","
@@ -29,11 +29,11 @@ std::ostream& operator<<(std::ostream& os, const AppOptions& appOptions) {
 }
 
 App::App(Scene&& scene, const AppOptions& options)
-    : options_(options),
-      stopWatch_(),
-      scene_(std::move(scene)),
-      camera_(),
-      rayTracer_(),
+    : options_    (options),
+      stopWatch_  (),
+      scene_      (std::move(scene)),
+      camera_     (),
+      rayTracer_  (),
       frameBuffer_(options.imageOutputSize) {
     if (options_.logInfo) {
         std::cout << Text::padSides(" Configuring App ", '*', 80) << "\n";
@@ -63,10 +63,12 @@ void App::run() {
         rayTracer_.traceScene(camera_, scene_, frameBuffer_);
         stopWatch_.stop();
         std::cout << "finished in " << stopWatch_.elapsedTime() << " seconds" << "\n";
-
+        
+        std::cout << "Writing file started...";
+        stopWatch_.start();
         Files::writePpmWithGammaCorrection(frameBuffer_, options_.imageOutputFile, options_.imageOutputGamma);
-        std::cout << "Wrote to file \'"              << options_.imageOutputFile << "\' "
-                  << "with gamma correction set to " << options_.imageOutputGamma << "\n\n";
+        stopWatch_.stop();
+        std::cout << "finished in " << stopWatch_.elapsedTime() << " seconds" << "\n";
     } else {
         rayTracer_.traceScene(camera_, scene_, frameBuffer_);
         Files::writePpmWithGammaCorrection(frameBuffer_, options_.imageOutputFile, options_.imageOutputGamma);

--- a/src/Files.hpp
+++ b/src/Files.hpp
@@ -1,54 +1,56 @@
 #pragma once
-#include <string>
-#include <istream>
-#include <ostream>
 #include <fstream>
 #include <exception>
 #include <filesystem>
 #include <assert.h>
-#include <string_view>
 #include "FrameBuffer.h"
 
 
 namespace detail {
-    inline bool pathExists(std::string_view path) {
-        return std::filesystem::exists(path);
-    }
-    inline bool hasExtension(std::string_view path, std::string_view extension) {
-        assert(extension[0] == '.');
-        return std::filesystem::path(path).extension().string() == extension;
-    }
     inline std::ifstream openPpmFileForReading(const std::string& filepath) {
-        if (!hasExtension(filepath, ".ppm")) {
-            throw std::runtime_error("Cannot read file `" + filepath + "` - does not end with .ppm");
+        if (std::filesystem::path(filepath).extension() != ".ppm") {
+            throw std::runtime_error("Cannot read file \'" + filepath + "\' - does not end with .ppm");
         }
-        if (!pathExists(filepath)) {
-            throw std::runtime_error("Cannot read file `" + filepath + "` - does not exist");
+        if (!std::filesystem::exists(filepath)) {
+            throw std::runtime_error("Cannot read file \'" + filepath + "\' - does not exist");
         }
 
         std::ifstream ifs(filepath, std::ios::in | std::ios::binary);
         if (!ifs) {
-            throw std::runtime_error("Cannot read file `" + filepath + "` - error while opening for write");
+            throw std::runtime_error("Cannot read file \'" + filepath + "\' - error while opening for write");
         }
         return ifs;
     }
     inline std::ofstream openPpmFileForWriting(const std::string& filepath) {
-        if (!hasExtension(filepath, ".ppm")) {
-            throw std::runtime_error("Cannot write file `" + filepath + "` - does not end with .ppm");
+        if (std::filesystem::path(filepath).extension() != ".ppm") {
+            throw std::runtime_error("Cannot write file \'" + filepath + "\' - does not end with .ppm");
         }
 
         std::ofstream ofs(filepath, std::ios::out | std::ios::binary);
         if (!ofs) {
-            throw std::runtime_error("Cannot write file `" + filepath + "` - error while opening for write");
+            throw std::runtime_error("Cannot write file \'" + filepath + "\' - error while opening for write");
         }
         return ofs;
     }
 }
 
 namespace Files {
+    inline bool pathExists(const std::string& filepath) {
+        return std::filesystem::exists(filepath);
+    }
+    inline std::string fileName(const std::string& filepath) {
+        return std::filesystem::path(filepath).filename().stem().string();
+    }
+    inline std::string fileExtension(const std::string filepath) {
+        return std::filesystem::path(filepath).extension().string();
+    }
+    inline std::string absolutePath(const std::string& filepath) {
+        return std::filesystem::canonical(filepath).string();
+    }
+
     // save framebuffer as an array of 256 rgb-colored pixels_, written to file at given location
     // note that the buffer stores colors relative to top left corner, while ppm is relative to the bottom left
-    inline FrameBuffer readPpm(const std::string filepath) {
+    inline FrameBuffer readPpm(const std::string& filepath) {
         std::ifstream ifs = detail::openPpmFileForReading(filepath);
 
         // read metadata from header, then skip ahead to binary color data
@@ -56,14 +58,14 @@ namespace Files {
         int bufferWidth, bufferHeight, numBytes;
         ifs >> header >> bufferWidth >> bufferHeight >> numBytes;
         if (header != "P6" || bufferWidth <= 0 || bufferHeight <= 0 || numBytes != 255) {
-            throw std::runtime_error("File `" + filepath + ".ppm` has an invalid header - expected magic number (P6), " +
+            throw std::runtime_error("File \'" + filepath + "\' has an invalid header - expected magic number (P6), " +
                                      "non-zero image dimensions, and byte size of 255");
         }
         ifs.ignore(256, '\n');
 
         FrameBuffer frameBuffer{ static_cast<size_t>(bufferWidth), static_cast<size_t>(bufferHeight) };
         unsigned char colorValues[3];
-        for (int i = 0; i < frameBuffer.numPixels(); ++i) {
+        for (size_t i = 0; i < frameBuffer.numPixels(); i++) {
             ifs.read(reinterpret_cast<char*>(colorValues), 3);
             frameBuffer.setPixel(i, Color(colorValues[0], colorValues[1], colorValues[2]));
         }
@@ -72,7 +74,7 @@ namespace Files {
 
     // save framebuffer as an array of 256 rgb-colored pixels_, written to file at given location
     // note that the buffer stores colors relative to top left corner, while ppm is relative to the bottom left
-    inline void writePpm(const FrameBuffer& frameBuffer, const std::string filepath) {
+    inline void writePpm(const std::string& filepath, const FrameBuffer& frameBuffer) {
         std::ofstream ofs = detail::openPpmFileForWriting(filepath);
         ofs << "P6\n" << frameBuffer.width() << " " << frameBuffer.height() << "\n255\n";
         for (size_t i = 0; i < frameBuffer.numPixels(); i++) {
@@ -84,7 +86,8 @@ namespace Files {
     }
     // save framebuffer as an array of 256 rgb-colored pixels_, written to file at given location
     // note that the buffer stores colors relative to top left corner, while ppm is relative to the bottom left
-    inline void writePpmWithGammaCorrection(const FrameBuffer& frameBuffer, const std::string filepath, float gammaCorrection=2.20f) {
+    inline void writePpmWithGammaCorrection(const std::string& filepath, const FrameBuffer& frameBuffer,
+                                            float gammaCorrection=2.20f) {
         std::ofstream ofs = detail::openPpmFileForWriting(filepath);
         const float invGamma = 1.00f / gammaCorrection;
         ofs << "P6\n" << frameBuffer.width() << " " << frameBuffer.height() << "\n255\n";

--- a/src/Files.hpp
+++ b/src/Files.hpp
@@ -44,7 +44,8 @@ namespace Files {
     inline std::string fileExtension(const std::string filepath) {
         return std::filesystem::path(filepath).extension().string();
     }
-    inline std::string absolutePath(const std::string& filepath) {
+    // assumes give path exists - otherwise system error is thrown
+    inline std::string resolveAbsolutePath(const std::string& filepath) {
         return std::filesystem::canonical(filepath).string();
     }
 


### PR DESCRIPTION
# App: Log output file info before, during, and after file writing
Adds logging for filename (without extension for denoting the scene), outputpath (canonical file system path), and timing of file write.