### PR TITLE
Fix building on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.15.0)
 
 project(RayTracer VERSION 0.1.0)
 set(CMAKE_CXX_STANDARD 20)
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+endif()
 
 add_compile_definitions(
   $<$<CONFIG:DEBUG>:DEBUG>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.15.0)
 
 project(RayTracer VERSION 0.1.0)
 set(CMAKE_CXX_STANDARD 20)
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-endif()
 
 add_compile_definitions(
   $<$<CONFIG:DEBUG>:DEBUG>

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "App.hpp"
 #include "Text.hpp"
 #include "Files.hpp"

--- a/src/Files.cpp
+++ b/src/Files.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "Files.hpp"
 #include "FrameBuffer.hpp"
 #include <fstream>

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "FrameBuffer.hpp"
 #include "Math.hpp"
 #include "Color.hpp"

--- a/src/Math.hpp
+++ b/src/Math.hpp
@@ -176,27 +176,27 @@ namespace Math {
     inline constexpr float DEG_TO_RAD      = PI / 180.00f;
 
     inline float sin(float degrees) {
-        return std::sinf(DEG_TO_RAD * degrees);
+        return std::sin(DEG_TO_RAD * degrees);
     }
 
     inline float cos(float degrees) {
-        return std::cosf(DEG_TO_RAD * degrees);
+        return std::cos(DEG_TO_RAD * degrees);
     }
 
     inline float tan(float degrees) {
-        return std::tanf(DEG_TO_RAD * degrees);
+        return std::tan(DEG_TO_RAD * degrees);
     }
 
     inline float asin(float ratio) {
-        return RAD_TO_DEG * std::asinf(ratio);
+        return RAD_TO_DEG * std::asin(ratio);
     }
 
     inline float acos(float ratio) {
-        return RAD_TO_DEG * std::acosf(ratio);
+        return RAD_TO_DEG * std::acos(ratio);
     }
 
     inline float atan(float ratio) {
-        return RAD_TO_DEG * std::atanf(ratio);
+        return RAD_TO_DEG * std::atan(ratio);
     }
 
     inline constexpr float radToDeg(float radians) {
@@ -209,11 +209,11 @@ namespace Math {
 
 
     inline float pow(float a, float b) {
-        return std::powf(a, b);
+        return std::pow(a, b);
     }
 
     inline float squareRoot(float a) {
-        return std::sqrtf(a);
+        return std::sqrt(a);
     }
 
     inline constexpr float square(float a) {

--- a/src/StopWatch.cpp
+++ b/src/StopWatch.cpp
@@ -1,4 +1,4 @@
-#include "Stopwatch.hpp"
+#include "StopWatch.hpp"
 #include <optional>
 #include <omp.h>
 


### PR DESCRIPTION
There is a "bug" with the GNU libc++ implementation where `std::sinf` and friends aren't defined in the `std` namespace and instead get put into the global namespace. Clang doesn't have this problem, however, I need to explicitly state that the standard library to use with clang is libc++. Alternatively, all the calls to the math functions could be converted to `std::sin` and friends which should have the same effect since there are overloads for the other types.